### PR TITLE
feat: add comprehensive dashboard with charts and AI analysis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,13 @@ jobs:
         include:
           - os: windows-latest
             os-short: windows
+            arch: amd64
           - os: macos-latest
             os-short: macos
+            arch: amd64
           - os: ubuntu-latest
             os-short: linux
+            arch: amd64
 
     steps:
       - name: Validate release tag
@@ -57,6 +60,17 @@ jobs:
           node-version: 18
           cache: npm
 
+      - name: Validate package version
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${RELEASE_TAG#v}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "::error::package.json version ($PACKAGE_VERSION) must match release tag without v ($RELEASE_VERSION)."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: npm install
 
@@ -70,25 +84,36 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          shopt -s nullglob
           npx electron-builder --publish=never
 
           # Collect output artifacts into release-assets
           mkdir -p release-assets
-          ASSET=""
+          assets=()
           if [[ "${{ matrix.os-short }}" == "windows" ]]; then
-            ASSET=$(ls dist/DickHelper*.exe | head -1)
+            assets=(dist/*.exe dist/*.exe.blockmap dist/latest.yml)
           elif [[ "${{ matrix.os-short }}" == "macos" ]]; then
-            ASSET=$(ls dist/DickHelper*.dmg | head -1)
+            assets=(dist/*.dmg dist/*.zip dist/*.zip.blockmap dist/latest-mac.yml)
           else
-            ASSET=$(ls dist/DickHelper*.AppImage | head -1)
+            assets=(dist/*.AppImage dist/*.AppImage.blockmap dist/latest-linux.yml)
           fi
-          cp "$ASSET" "release-assets/dickhelper-${{ env.RELEASE_TAG }}-${{ matrix.os-short }}.${ASSET##*.}"
+
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::error::No release assets found in dist/"
+            ls -la dist/ || true
+            exit 1
+          fi
+
+          for asset in "${assets[@]}"; do
+            cp "$asset" release-assets/
+          done
+
           echo "Release asset: $(ls -lh release-assets/)"
 
       - name: Upload release asset artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ env.RELEASE_TAG }}-${{ matrix.os-short }}
+          name: release-${{ env.RELEASE_TAG }}-${{ matrix.os-short }}-${{ matrix.arch }}
           path: release-assets/*
           if-no-files-found: error
           retention-days: 7
@@ -119,7 +144,7 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
-          assets=(release-assets/dickhelper*)
+          assets=(release-assets/*)
           echo "Found ${#assets[@]} release asset(s):"
           for a in "${assets[@]}"; do
             echo "  - $a ($(du -h "$a" | cut -f1))"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# DickHelper -- 项目总览
+
+> 牛子小助手：一个基于 Electron + React + TypeScript 的跨平台桌面应用，用于科学记录和统计个人生活数据。
+
+## 项目愿景
+
+提供一个简洁、隐私优先的本地桌面工具，帮助用户记录、统计和管理个人打飞机数据。所有数据完全存储在本地 SQLite 数据库中，不上传任何服务器。
+
+## 架构总览
+
+三层 Electron 架构，通过 IPC 通道进行进程间通信：
+
+| 层 | 位置 | 职责 |
+|---|---|---|
+| Main（主进程） | `src/main/` | SQLite 持久化、IPC 处理、窗口/托盘管理 |
+| Preload（预加载） | `src/preload/` | 安全边界，通过 `contextBridge` 暴露白名单 API |
+| Renderer（渲染进程） | `src/renderer/` | React UI、视图切换、数据展示 |
+
+数据流方向：`Renderer --> (IPC invoke) --> Main --> SQLite --> (IPC reply) --> Renderer`
+
+## 模块结构图
+
+```mermaid
+graph TD
+    A["DickHelper (根)"] --> B["src/main"]
+    A --> C["src/preload"]
+    A --> D["src/renderer"]
+    D --> E["views"]
+    D --> F["hooks"]
+    D --> G["services"]
+    D --> H["types"]
+
+    click B "./src/main/CLAUDE.md" "查看 main 模块文档"
+    click C "./src/preload/CLAUDE.md" "查看 preload 模块文档"
+    click D "./src/renderer/CLAUDE.md" "查看 renderer 模块文档"
+```
+
+## 模块索引
+
+| 模块 | 路径 | 语言 | 职责概述 |
+|------|------|------|---------|
+| Main | `src/main/` | TypeScript | Electron 主进程：窗口创建、系统托盘、IPC 注册、SQLite 数据库 |
+| Preload | `src/preload/` | TypeScript | 安全沙箱桥接层，暴露 `window.electronAPI` |
+| Renderer | `src/renderer/` | TypeScript/TSX | React UI 层：视图、Hooks、服务封装、类型定义 |
+
+## 运行与开发
+
+### 前置要求
+
+- Node.js >= 18
+- npm >= 9
+
+### 常用命令
+
+```bash
+npm install          # 安装依赖
+npm run dev          # 启动开发模式（Vite dev server + Electron 热重载）
+npm run build        # 构建生产版本（输出到 out/）
+npm run preview      # 预览构建结果
+npx tsc -b --noEmit  # 类型检查
+```
+
+### 构建与打包
+
+- 构建工具：`electron-vite` + `Vite 6`
+- 打包工具：`electron-builder`（配置见 `electron-builder.yml`）
+- 构建产物：`out/main/`、`out/preload/`、`out/renderer/`
+- 分发产物：`dist/`（exe/dmg/AppImage）
+
+### CI/CD
+
+GitHub Actions 工作流 `.github/workflows/release.yml`：
+- 触发条件：推送 `v*.*.*` 标签 / 发布 Release / 手动触发
+- 三平台并行构建（Windows/macOS/Linux）
+- 自动上传到 GitHub Release
+
+## 技术栈
+
+| 组件 | 选型 |
+|------|------|
+| 桌面框架 | Electron 35 |
+| UI 框架 | React 19.1 |
+| 语言 | TypeScript 5.7（strict 模式） |
+| 构建 | electron-vite + Vite 6 |
+| 组件库 | Mantine 7 |
+| 图标库 | @tabler/icons-react |
+| 数据库 | SQLite（sql.js WASM） |
+| 路由 | 无路由库，useState 视图切换 |
+| 状态管理 | SQLite + React 本地状态（无全局状态库） |
+
+## 测试策略
+
+当前项目**没有测试文件**。无单元测试、集成测试或端到端测试。类型检查（`tsc -b --noEmit`）是唯一的静态验证手段。
+
+## 编码规范
+
+- **命名风格**：C# / .NET 风格 PascalCase
+  - 组件：`RecordForm`、`StatsChart`
+  - 服务方法：`DatabaseService.GetRecords()`
+  - Hooks：`useRecords`、`useTimer`（React 惯例）
+  - 接口：`I` 前缀（`IRecord`、`IStats`）
+- **TypeScript**：strict 模式启用全部严格检查（`noUnusedLocals`、`noUncheckedIndexedAccess` 等）
+- **注释语言**：代码注释使用中文，文档使用中英双语
+- **架构约束**：Main 进程代码不得导入 Renderer（反之亦然），通过 IPC 通信
+
+## AI 使用指引
+
+- 本项目是 **Electron 桌面应用**，不是 Flutter/Dart 项目
+- 数据层在 Main 进程（`src/main/database.ts`），UI 层在 Renderer（`src/renderer/`）
+- 修改数据操作需同时更新：Main IPC handler、Preload 桥接、Renderer DatabaseService、类型定义
+- 新增视图放 `src/renderer/views/`，新增 Hook 放 `src/renderer/hooks/`
+- 数据访问逻辑放 `src/renderer/services/`，不要写在组件里
+- 日期在 IPC 传输时使用 ISO 8601 字符串，Renderer 侧转为 `Date` 对象
+- 项目使用 `.trellis/` 目录管理开发规范（见 `.trellis/spec/`），该目录标记为 `linguist-vendored`
+
+## 关键文件速查
+
+| 文件 | 用途 |
+|------|------|
+| `src/main/index.ts` | 应用入口：窗口创建、托盘、IPC 注册 |
+| `src/main/database.ts` | SQLite 数据库服务（CRUD + 统计 + 导入） |
+| `src/preload/index.ts` | contextBridge 暴露 electronAPI |
+| `src/preload/index.d.ts` | electronAPI 类型声明 |
+| `src/renderer/App.tsx` | React 根组件：MantineProvider + AppShell + 视图切换 |
+| `src/renderer/services/DatabaseService.ts` | Renderer 侧 IPC 调用封装 + 导入导出 |
+| `src/renderer/hooks/useTimer.ts` | 计时器逻辑（开始/暂停/继续/停止） |
+| `src/renderer/hooks/useRecords.ts` | 记录数据加载 + IPC 事件监听自动刷新 |
+| `electron.vite.config.ts` | electron-vite 构建配置 |
+| `electron-builder.yml` | 打包配置（appId: com.york.dickhelper） |
+| `.github/workflows/release.yml` | 三平台 CI/CD 发布流水线 |
+
+## 变更记录 (Changelog)
+
+| 时间 | 操作 | 说明 |
+|------|------|------|
+| 2026-05-24 00:43:49 | 初始生成 | 首次全量扫描，生成根级 + 模块级 CLAUDE.md 及 index.json |
+
+# 每次修改完commit
+
+每次修改完需要对自己修改的部分commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,14 +94,51 @@ GitHub Actions 工作流 `.github/workflows/release.yml`：
 
 ## 编码规范
 
-- **命名风格**：C# / .NET 风格 PascalCase
-  - 组件：`RecordForm`、`StatsChart`
-  - 服务方法：`DatabaseService.GetRecords()`
-  - Hooks：`useRecords`、`useTimer`（React 惯例）
-  - 接口：`I` 前缀（`IRecord`、`IStats`）
-- **TypeScript**：strict 模式启用全部严格检查（`noUnusedLocals`、`noUncheckedIndexedAccess` 等）
-- **注释语言**：代码注释使用中文，文档使用中英双语
-- **架构约束**：Main 进程代码不得导入 Renderer（反之亦然），通过 IPC 通信
+### 命名风格（C# / .NET 风格）
+
+| 类别 | 风格 | 示例 |
+|------|------|------|
+| 函数 / 方法 | PascalCase | `GetRecords()`、`HandleStartStop()`、`FormatTime()` |
+| 组件 | PascalCase 箭头函数 | `export const RecordForm = () => {` |
+| 局部变量 | 工具函数中 PascalCase | `const preloadPath: string = ...` |
+| React 状态 | camelCase（React 惯例） | `const [notes, setNotes] = useState(...)` |
+| Hook | camelCase `use` 前缀 | `useTimer`、`useRecords` |
+| Hook 返回值 | PascalCase | `IsRecording`、`Start`、`Pause` |
+| 接口 | `I` 前缀 + PascalCase | `IRecord`、`IStats`、`IImportResult` |
+| 接口字段 | PascalCase + `readonly` | `readonly StartTime: Date` |
+| 常量 | UPPER_SNAKE | `const IS_DEV: boolean = ...` |
+
+### 类型注解
+
+所有变量、参数、返回值必须显式标注类型，不依赖推断：
+
+```typescript
+// 正确
+const statusLabel: string = "未开始";
+function CreateWindow(): void { ... }
+public static async GetRecords(): Promise<IRecord[]> { ... }
+
+// 错误 — 缺少类型注解
+const statusLabel = "未开始";
+function CreateWindow() { ... }
+```
+
+### 禁止事项
+
+- **禁止 `any`**：用 `unknown` + 类型守卫代替（参考 `ImportFromJson` 中 `rawData: unknown` 的处理）
+- **禁止滥用抽象**：不要引入 DI 容器、中间件链、事件总线等。直接调用优先（组件直接调 `DatabaseService` 静态方法）
+- **禁止过度解耦**：不要为了"可扩展"拆出只用一次的接口/工厂/策略。三层架构（Main/Preload/Renderer）已经够了
+- **禁止过度设计**：4 个视图用 `useState` 切换，不需要 React Router；数据用 SQLite 本地状态，不需要 Redux/Zustand
+- **禁止 default export**：全部使用 named export
+- **禁止隐式 falsy 检查**：用 `!== null`、`!== undefined` 代替 `if (!value)`
+
+### 代码组织
+
+- 注释语言：中文，简洁说明"为什么"
+- 组件风格：箭头函数 + named export，不用 `function` 声明
+- 服务层：静态类方法（`DatabaseService.GetRecords()`），不实例化
+- 架构约束：Main 进程代码不得导入 Renderer（反之亦然），通过 IPC 通信
+- TypeScript：strict 模式启用全部严格检查（`noUnusedLocals`、`noUncheckedIndexedAccess` 等）
 
 ## AI 使用指引
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ npm run build
 - `out/preload/` — 预加载脚本
 - `out/renderer/` — React 渲染进程（静态文件）
 
-> 自动更新和安装包打包（electron-builder）暂未配置，后续版本添加。
+打包工具 `electron-builder` 已配置（见 `electron-builder.yml`），支持三平台输出：
+- **Windows**: NSIS 安装包
+- **macOS**: DMG
+- **Linux**: AppImage
+
+CI/CD 通过 GitHub Actions（`.github/workflows/release.yml`）自动构建并上传到 GitHub Release。
 
 ## 技术栈 | Tech Stack
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default tseslint.config(
+  { ignores: ["out/", "dist/", "node_modules/", "*.config.*"] },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  {
+    languageOptions: {
+      globals: globals.node,
+    },
+    files: ["src/main/**/*.ts", "src/preload/**/*.ts"],
+  },
+
+  {
+    files: ["src/renderer/**/*.{ts,tsx}"],
+    languageOptions: {
+      globals: globals.browser,
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,16 @@
       "name": "dickhelper",
       "version": "2.0.0",
       "dependencies": {
-        "@mantine/core": "^7.17.0",
-        "@mantine/hooks": "^7.17.0",
-        "@tabler/icons-react": "^3.31.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "recharts": "^3.8.1",
         "sql.js": "^1.14.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@mantine/core": "^7.17.0",
+        "@mantine/hooks": "^7.17.0",
+        "@tabler/icons-react": "^3.31.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@types/sql.js": "^1.4.11",
@@ -28,10 +29,72 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.18",
         "globals": "^15.14.0",
+        "jsdom": "^29.1.1",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
-        "vite": "^6.1.0"
+        "vite": "^6.1.0",
+        "vitest": "^4.1.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -88,13 +151,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
-    },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
@@ -294,6 +350,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -345,6 +402,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1401,10 +1611,29 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
@@ -1414,6 +1643,7 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
@@ -1424,6 +1654,7 @@
       "version": "0.26.28",
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
       "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
@@ -1439,6 +1670,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
       "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6"
@@ -1452,6 +1684,7 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -1665,6 +1898,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz",
       "integrity": "sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
@@ -1684,6 +1918,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz",
       "integrity": "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
@@ -1725,6 +1960,42 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2090,6 +2361,18 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2107,6 +2390,7 @@
       "version": "3.44.0",
       "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
       "integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2117,6 +2401,7 @@
       "version": "3.44.0",
       "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.44.0.tgz",
       "integrity": "sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tabler/icons": "3.44.0"
@@ -2128,6 +2413,90 @@
       "peerDependencies": {
         "react": ">= 16"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2187,6 +2556,80 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2196,6 +2639,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/emscripten": {
       "version": "1.41.5",
@@ -2314,6 +2764,12 @@
         "@types/emscripten": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -2545,6 +3001,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -2905,6 +3474,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2914,6 +3493,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -3000,6 +3589,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/boolean": {
@@ -3272,6 +3871,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
@@ -3437,6 +4046,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3480,12 +4096,168 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -3504,6 +4276,19 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3599,6 +4384,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -3611,6 +4406,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dir-compare": {
@@ -3729,6 +4525,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4050,6 +4854,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4087,6 +4904,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -4115,6 +4939,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -4380,6 +5214,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
@@ -4388,6 +5232,22 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -4700,6 +5560,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5010,6 +5871,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -5122,6 +5996,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5149,6 +6033,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5167,6 +6061,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -5210,6 +6113,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -5277,6 +6187,67 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -5425,6 +6396,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5458,6 +6440,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5523,6 +6512,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5796,6 +6795,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5879,6 +6889,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
@@ -5908,6 +6931,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
@@ -6035,6 +7065,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -6157,14 +7217,45 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-number-format": {
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
       "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -6181,6 +7272,7 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
       "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -6206,6 +7298,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
@@ -6228,6 +7321,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
@@ -6250,6 +7344,7 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
       "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -6276,10 +7371,79 @@
         "read-binary-file-arch": "cli.js"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6303,6 +7467,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
@@ -6485,6 +7655,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -6562,6 +7745,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -6669,6 +7859,13 @@
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -6678,6 +7875,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6702,6 +7906,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6746,10 +7963,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tar": {
@@ -6863,6 +8088,29 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6911,6 +8159,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.32.tgz",
+      "integrity": "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.32"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.32.tgz",
+      "integrity": "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -6944,6 +8222,32 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -6971,6 +8275,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -6990,6 +8295,7 @@
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -7107,6 +8413,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -7128,6 +8435,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
       "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7142,6 +8450,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
       "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7156,6 +8465,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
       "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.1"
@@ -7173,6 +8483,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -7189,6 +8500,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf8-byte-length": {
@@ -7212,6 +8532,28 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -7320,6 +8662,157 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
@@ -7334,6 +8827,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -7371,6 +8881,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -7380,6 +8900,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,6 @@
         "@mantine/core": "^7.17.0",
         "@mantine/hooks": "^7.17.0",
         "@tabler/icons-react": "^3.31.0",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@types/sql.js": "^1.4.11",
@@ -29,72 +27,12 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.18",
         "globals": "^15.14.0",
-        "jsdom": "^29.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
-        "vite": "^6.1.0",
-        "vitest": "^4.1.7"
+        "vite": "^6.1.0"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
-      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -151,6 +89,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
@@ -402,159 +347,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
-    "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
-      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1611,24 +1403,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
-      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -2414,90 +2188,6 @@
         "react": ">= 16"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2554,17 +2244,6 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
-      }
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*",
-        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -2639,13 +2318,6 @@
       "dependencies": {
         "@types/ms": "*"
       }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/emscripten": {
       "version": "1.41.5",
@@ -3001,119 +2673,6 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.7",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.7",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3474,16 +3033,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3493,16 +3042,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -3589,16 +3128,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/boolean": {
@@ -3871,16 +3400,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
@@ -4046,13 +3565,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4095,27 +3607,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -4245,20 +3736,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.0.tgz",
@@ -4276,13 +3753,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -4382,16 +3852,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-node": {
@@ -4525,14 +3985,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4854,19 +4306,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4903,13 +4342,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -5214,16 +4646,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
@@ -5239,16 +4661,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
-    },
-    "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -5871,19 +5283,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.6.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -6033,16 +5432,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6114,13 +5503,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
@@ -6187,67 +5569,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
-        "parse5": "^8.0.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -6396,17 +5717,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6440,13 +5750,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6512,16 +5815,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6795,17 +6088,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6889,19 +6171,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
@@ -6931,13 +6200,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
@@ -7065,36 +6327,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -7218,9 +6450,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT",
       "peer": true
     },
@@ -7401,20 +6633,6 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -7434,16 +6652,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7655,19 +6863,6 @@
         "node": ">=11.0.0"
       }
     },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7745,13 +6940,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -7859,13 +7047,6 @@
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
       "license": "MIT"
     },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -7875,13 +7056,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -7906,19 +7080,6 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -7962,13 +7123,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -8094,23 +7248,6 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
-    "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
-      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -8159,36 +7296,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tldts": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.32.tgz",
-      "integrity": "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.0.32"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.32.tgz",
-      "integrity": "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -8220,32 +7327,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -8662,157 +7743,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
@@ -8827,23 +7757,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/why-is-node-running": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -8881,16 +7794,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -8900,13 +7803,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,13 @@
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
-    "preview": "electron-vite preview"
+    "preview": "electron-vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
   },
   "dependencies": {
+    "recharts": "^3.8.1",
     "sql.js": "^1.14.0"
   },
   "devDependencies": {
@@ -17,6 +21,8 @@
     "@mantine/core": "^7.17.0",
     "@mantine/hooks": "^7.17.0",
     "@tabler/icons-react": "^3.31.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@types/sql.js": "^1.4.11",
@@ -24,14 +30,16 @@
     "electron": "^35.0.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^3.0.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "eslint": "^9.19.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
+    "jsdom": "^29.1.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",
-    "vite": "^6.1.0"
+    "vite": "^6.1.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/src/main/CLAUDE.md
+++ b/src/main/CLAUDE.md
@@ -1,0 +1,105 @@
+[根目录](../../CLAUDE.md) > [src](../) > **main**
+
+# Main 模块 -- Electron 主进程
+
+## 模块职责
+
+Electron 主进程层，负责：
+- 应用生命周期管理（`app.whenReady`、`before-quit`）
+- BrowserWindow 创建与配置
+- 系统托盘（Tray）管理（关闭窗口缩到托盘）
+- SQLite 数据库初始化与持久化
+- IPC 通道注册（`ipcMain.handle`）
+
+## 入口与启动
+
+- **入口文件**：`index.ts`
+- **启动流程**：
+  1. `app.whenReady()` 触发
+  2. `DatabaseService.create()` 异步初始化 SQLite（sql.js WASM）
+  3. `RegisterIpcHandlers()` 注册所有 IPC 通道
+  4. `CreateWindow()` 创建 BrowserWindow（`show: false`，等 `ready-to-show` 再显示）
+  5. `CreateTray()` 创建系统托盘
+
+## 对外接口
+
+### IPC 通道（Main -> Renderer 通过 `ipcMain.handle`）
+
+| 通道名 | 参数 | 返回值 | 说明 |
+|--------|------|--------|------|
+| `records:get-all` | 无 | `IDbRecord[]` | 获取所有记录，按 EndTime 降序 |
+| `records:save` | `startTime, endTime, duration, notes?` | `IDbRecord` | 保存新记录 |
+| `records:delete` | `id` | `boolean` | 删除单条记录 |
+| `records:clear-all` | 无 | `void` | 清空所有记录 |
+| `records:get-stats` | 无 | `IStats` | 获取统计数据（总数/平均时长/周频/月频） |
+| `records:get-daily-counts` | `startTimestamp, endTimestamp` | `IDailyCount[]` | 获取日期范围内每日计数 |
+| `records:import` | `records[]` | `IImportResult` | 批量导入（带去重和校验） |
+
+### IPC 事件（Main -> Renderer 通过 `webContents.send`）
+
+| 事件名 | 触发时机 |
+|--------|---------|
+| `records-updated` | 保存、删除、清空、导入操作后 |
+
+## 关键依赖与配置
+
+| 依赖 | 用途 |
+|------|------|
+| `sql.js` | SQLite WASM 实现，在 Node.js 主进程中运行 |
+| `electron` | 桌面应用框架 |
+| `node:crypto` | `randomUUID()` 生成记录 ID |
+| `node:fs` | 数据库文件读写（`dickhelper.db`） |
+
+- 数据库路径：`app.getPath("userData")/dickhelper.db`
+- 窗口配置：960x680，最小 800x600，背景色 `#f5f5f5`
+- 安全配置：`contextIsolation: true`，`nodeIntegration: false`
+
+## 数据模型
+
+### Records 表
+
+```sql
+CREATE TABLE IF NOT EXISTS Records (
+    Id        TEXT PRIMARY KEY,    -- UUID
+    StartTime TEXT NOT NULL,       -- ISO 8601
+    EndTime   TEXT NOT NULL,       -- ISO 8601
+    Duration  REAL NOT NULL,       -- 分钟（浮点数）
+    Notes     TEXT                 -- 可选备注
+)
+```
+
+### DatabaseService 类
+
+- **工厂模式**：`DatabaseService.create()` 异步创建实例（WASM 初始化是异步的）
+- **私有方法**：`_save()` 将内存数据库导出到文件、`_queryAll()` / `_queryOne()` 查询封装
+- **公开方法**：`GetRecords`、`SaveRecord`、`DeleteRecord`、`ClearAll`、`GetStats`、`GetDailyCounts`、`ImportRecords`、`RecordExists`、`Close`
+
+## 测试与质量
+
+- 无测试文件
+- 类型安全：TypeScript strict 模式
+- 缺口：无单元测试覆盖 DatabaseService 的 CRUD 和边界情况
+
+## 常见问题 (FAQ)
+
+**Q: 为什么用 sql.js 而不是 better-sqlite3？**
+sql.js 是纯 WASM 实现，不需要 native 编译，跨平台打包更简单。
+
+**Q: 数据库文件在哪里？**
+`app.getPath("userData")/dickhelper.db`，Windows 上通常是 `%APPDATA%/dickhelper/`。
+
+**Q: 关闭窗口会退出应用吗？**
+不会。关闭窗口时会缩到系统托盘，需要通过托盘右键菜单"退出"才能真正退出。
+
+## 相关文件清单
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `index.ts` | 194 | 应用入口、窗口、托盘、IPC 注册 |
+| `database.ts` | 257 | DatabaseService：SQLite CRUD + 统计 + 导入 |
+
+## 变更记录 (Changelog)
+
+| 时间 | 操作 | 说明 |
+|------|------|------|
+| 2026-05-24 00:43:49 | 初始生成 | 首次扫描生成 |

--- a/src/main/ai-service.ts
+++ b/src/main/ai-service.ts
@@ -194,7 +194,9 @@ const AnalyzeWithGoogle = async (data: IAiAnalysisData, apiKey: string, model: s
 
 const CLI_TIMEOUT_MS: number = 120_000;
 
-const AnalyzeWithCli = (data: IAiAnalysisData, command: string): Promise<string> => {
+const MAX_CLI_OUTPUT_BYTES: number = 1_048_576;
+
+const AnalyzeWithCli = async (data: IAiAnalysisData, command: string): Promise<string> => {
     if (command.trim() === "") {
         throw new Error("未配置 CLI 命令");
     }
@@ -208,36 +210,55 @@ const AnalyzeWithCli = (data: IAiAnalysisData, command: string): Promise<string>
 
         const child = spawn(bin, args, {
             stdio: ["pipe", "pipe", "pipe"],
-            shell: true,
             timeout: CLI_TIMEOUT_MS,
         });
 
         const stdout: Buffer[] = [];
         const stderr: Buffer[] = [];
+        let totalBytes: number = 0;
+        let settled: boolean = false;
 
-        child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+        const settle = (fn: () => void): void => {
+            if (settled) return;
+            settled = true;
+            fn();
+        };
+
+        child.stdout.on("data", (chunk: Buffer) => {
+            totalBytes += chunk.length;
+            if (totalBytes > MAX_CLI_OUTPUT_BYTES) {
+                child.kill();
+                settle(() => reject(new Error("CLI 输出超过 1MB 限制")));
+                return;
+            }
+            stdout.push(chunk);
+        });
         child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
 
         child.on("error", (err: Error) => {
-            reject(new Error(`CLI 启动失败: ${err.message}`));
+            settle(() => reject(new Error(`CLI 启动失败: ${err.message}`)));
         });
 
         child.on("close", (code: number | null) => {
             const out: string = Buffer.concat(stdout).toString("utf-8").trim();
             if (code !== 0) {
                 const errMsg: string = Buffer.concat(stderr).toString("utf-8").trim();
-                reject(new Error(`CLI 退出码 ${code ?? "null"}: ${errMsg || out || "无输出"}`));
+                settle(() => reject(new Error(`CLI 退出码 ${code ?? "null"}: ${errMsg || out || "无输出"}`)));
                 return;
             }
             if (out === "") {
-                reject(new Error("CLI 命令无输出"));
+                settle(() => reject(new Error("CLI 命令无输出")));
                 return;
             }
-            resolve(out);
+            settle(() => resolve(out));
         });
 
-        child.stdin.write(prompt);
-        child.stdin.end();
+        try {
+            child.stdin.write(prompt);
+            child.stdin.end();
+        } catch {
+            // 进程可能已退出，error/close 事件会处理
+        }
     });
 };
 

--- a/src/main/ai-service.ts
+++ b/src/main/ai-service.ts
@@ -211,6 +211,7 @@ const AnalyzeWithCli = async (data: IAiAnalysisData, command: string): Promise<s
         const child = spawn(bin, args, {
             stdio: ["pipe", "pipe", "pipe"],
             timeout: CLI_TIMEOUT_MS,
+            shell: true,
         });
 
         const stdout: Buffer[] = [];

--- a/src/main/ai-service.ts
+++ b/src/main/ai-service.ts
@@ -1,0 +1,226 @@
+// AI 分析服务：支持 Anthropic / OpenAI / Ollama / 本地规则四种 provider
+
+interface IAiAnalysisData {
+    TotalCount: number;
+    AverageDuration: number;
+    FrequencyPerWeek: number;
+    FrequencyPerMonth: number;
+    HourlyDistribution: { Hour: number; Count: number }[];
+    WeekdayDistribution: { Weekday: number; Count: number }[];
+    MonthlyTrend: { Month: string; Count: number }[];
+    DurationStats: { Min: number; Max: number; Avg: number; Median: number };
+}
+
+interface IAiConfig {
+    Provider: "anthropic" | "openai" | "ollama" | "local";
+    ApiKey: string;
+    OllamaUrl: string;
+    OllamaModel: string;
+}
+
+const WEEKDAY_NAMES: string[] = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
+const FETCH_TIMEOUT_MS: number = 30_000;
+
+const BuildPrompt = (data: IAiAnalysisData): string => {
+    const hourlyPeaks = [...data.HourlyDistribution]
+        .sort((a, b) => b.Count - a.Count)
+        .slice(0, 3);
+
+    return `你是一个健康数据分析助手。请基于以下统计数据，给出简洁的分析和建议（中文回答，200字以内）：
+
+统计概览：
+- 总次数：${data.TotalCount}
+- 平均时长：${data.AverageDuration.toFixed(1)} 分钟
+- 本周频率：${data.FrequencyPerWeek} 次
+- 本月频率：${data.FrequencyPerMonth} 次
+
+高峰时段（前3）：
+${hourlyPeaks.map((h) => `- ${h.Hour}:00：${h.Count} 次`).join("\n")}
+
+星期分布：
+${data.WeekdayDistribution.map((d) => `- ${WEEKDAY_NAMES[d.Weekday] ?? "?"}：${d.Count} 次`).join("\n")}
+
+时长统计：
+- 最短：${data.DurationStats.Min.toFixed(1)} 分钟
+- 最长：${data.DurationStats.Max.toFixed(1)} 分钟
+- 中位数：${data.DurationStats.Median.toFixed(1)} 分钟
+
+月度趋势（最近数月）：
+${data.MonthlyTrend.slice(-6).map((m) => `- ${m.Month}：${m.Count} 次`).join("\n")}
+
+请分析：1. 行为模式特点 2. 频率是否健康 3. 简短建议`;
+};
+
+// 带超时的 fetch 封装
+const FetchWithTimeout = (url: string, options: RequestInit): Promise<Response> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timer));
+};
+
+// Ollama 仅允许连接本地地址
+const ValidateOllamaUrl = (url: string): void => {
+    const parsed = new URL(url);
+    const allowedHosts = ["localhost", "127.0.0.1", "[::1]", "::1"];
+    if (!allowedHosts.includes(parsed.hostname)) {
+        throw new Error(`Ollama 地址仅允许本地连接（localhost/127.0.0.1），当前: ${parsed.hostname}`);
+    }
+};
+
+// 从 API 响应中安全提取文本
+const ExtractAnthropicText = (result: unknown): string => {
+    const body = result as Record<string, unknown> | null;
+    if (body === null || typeof body !== "object") throw new Error("Anthropic 返回格式异常");
+    const content = body.content;
+    if (!Array.isArray(content) || content.length === 0) throw new Error("Anthropic 返回内容为空");
+    const first = content[0] as Record<string, unknown> | undefined;
+    if (first === undefined || typeof first.text !== "string") throw new Error("Anthropic 返回格式异常");
+    return first.text;
+};
+
+const ExtractOpenAiText = (result: unknown): string => {
+    const body = result as Record<string, unknown> | null;
+    if (body === null || typeof body !== "object") throw new Error("OpenAI 返回格式异常");
+    const choices = body.choices;
+    if (!Array.isArray(choices) || choices.length === 0) throw new Error("OpenAI 返回内容为空");
+    const first = choices[0] as Record<string, unknown> | undefined;
+    if (first === undefined || typeof first !== "object") throw new Error("OpenAI 返回格式异常");
+    const message = (first as Record<string, unknown>).message as Record<string, unknown> | undefined;
+    if (message === undefined || typeof message.content !== "string") throw new Error("OpenAI 返回格式异常");
+    return message.content;
+};
+
+const ExtractOllamaText = (result: unknown): string => {
+    const body = result as Record<string, unknown> | null;
+    if (body === null || typeof body !== "object" || typeof body.response !== "string") {
+        throw new Error("Ollama 返回格式异常");
+    }
+    return body.response;
+};
+
+const AnalyzeWithAnthropic = async (data: IAiAnalysisData, apiKey: string): Promise<string> => {
+    const response = await FetchWithTimeout("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+            model: "claude-haiku-4-5-20251001",
+            max_tokens: 1024,
+            messages: [{ role: "user", content: BuildPrompt(data) }],
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`Anthropic API 错误: ${response.status}`);
+    }
+    return ExtractAnthropicText(await response.json());
+};
+
+const AnalyzeWithOpenAi = async (data: IAiAnalysisData, apiKey: string): Promise<string> => {
+    const response = await FetchWithTimeout("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+            model: "gpt-4o-mini",
+            messages: [{ role: "user", content: BuildPrompt(data) }],
+            max_tokens: 1024,
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`OpenAI API 错误: ${response.status}`);
+    }
+    return ExtractOpenAiText(await response.json());
+};
+
+const AnalyzeWithOllama = async (data: IAiAnalysisData, url: string, model: string): Promise<string> => {
+    ValidateOllamaUrl(url);
+    const response = await FetchWithTimeout(`${url}/api/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            model,
+            prompt: BuildPrompt(data),
+            stream: false,
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`Ollama API 错误: ${response.status}`);
+    }
+    return ExtractOllamaText(await response.json());
+};
+
+const AnalyzeLocally = (data: IAiAnalysisData): string => {
+    if (data.TotalCount === 0) {
+        return "暂无数据记录，开始记录后即可获得分析洞察。";
+    }
+
+    const insights: string[] = [];
+
+    // 高峰时段
+    const peakHours = [...data.HourlyDistribution]
+        .filter((h) => h.Count > 0)
+        .sort((a, b) => b.Count - a.Count);
+    if (peakHours.length > 0) {
+        const top = peakHours[0]!;
+        const period = top.Hour < 6 ? "凌晨" : top.Hour < 12 ? "上午" : top.Hour < 18 ? "下午" : "晚上";
+        insights.push(`📍 高峰时段集中在${period} ${top.Hour}:00 左右（${top.Count} 次）。`);
+    }
+
+    // 星期分布
+    const peakDay = data.WeekdayDistribution.reduce(
+        (max, d) => (d.Count > max.Count ? d : max),
+        data.WeekdayDistribution[0]!
+    );
+    if (peakDay.Count > 0) {
+        insights.push(`📅 ${WEEKDAY_NAMES[peakDay.Weekday] ?? "?"}是最活跃的一天（${peakDay.Count} 次）。`);
+    }
+
+    // 频率评估
+    const weeklyAvg: number = data.FrequencyPerMonth / 4;
+    if (weeklyAvg <= 3) {
+        insights.push(`✅ 周均频率约 ${weeklyAvg.toFixed(1)} 次，频率适中。`);
+    } else if (weeklyAvg <= 7) {
+        insights.push(`⚠️ 周均频率约 ${weeklyAvg.toFixed(1)} 次，频率偏高，建议适当控制。`);
+    } else {
+        insights.push(`🔴 周均频率约 ${weeklyAvg.toFixed(1)} 次，频率较高，建议关注身体状况。`);
+    }
+
+    // 时长
+    if (data.DurationStats.Avg > 0) {
+        insights.push(`⏱️ 平均时长 ${data.DurationStats.Avg.toFixed(1)} 分钟，中位数 ${data.DurationStats.Median.toFixed(1)} 分钟。`);
+    }
+
+    // 趋势
+    const recentMonths = data.MonthlyTrend.slice(-3);
+    if (recentMonths.length >= 2) {
+        const last = recentMonths[recentMonths.length - 1]!;
+        const prev = recentMonths[recentMonths.length - 2]!;
+        if (last.Count > prev.Count) {
+            insights.push(`📈 近期趋势上升：本月（${last.Count} 次）比上月（${prev.Count} 次）增加。`);
+        } else if (last.Count < prev.Count) {
+            insights.push(`📉 近期趋势下降：本月（${last.Count} 次）比上月（${prev.Count} 次）减少。`);
+        } else {
+            insights.push(`➡️ 近期趋势稳定，最近两个月均为 ${last.Count} 次。`);
+        }
+    }
+
+    return insights.join("\n\n");
+};
+
+export const Analyze = async (data: IAiAnalysisData, config: IAiConfig): Promise<string> => {
+    switch (config.Provider) {
+        case "anthropic":
+            return AnalyzeWithAnthropic(data, config.ApiKey);
+        case "openai":
+            return AnalyzeWithOpenAi(data, config.ApiKey);
+        case "ollama":
+            return AnalyzeWithOllama(data, config.OllamaUrl, config.OllamaModel);
+        case "local":
+            return AnalyzeLocally(data);
+    }
+};

--- a/src/main/ai-service.ts
+++ b/src/main/ai-service.ts
@@ -1,4 +1,6 @@
-// AI 分析服务：支持 Anthropic / OpenAI / Ollama / 本地规则四种 provider
+// AI 分析服务：支持 Anthropic / OpenAI / Google / Ollama / CLI / 本地规则六种 provider
+
+import { spawn } from "node:child_process";
 
 interface IAiAnalysisData {
     TotalCount: number;
@@ -12,10 +14,12 @@ interface IAiAnalysisData {
 }
 
 interface IAiConfig {
-    Provider: "anthropic" | "openai" | "ollama" | "local";
+    Provider: "anthropic" | "openai" | "google" | "ollama" | "cli" | "local";
     ApiKey: string;
     OllamaUrl: string;
     OllamaModel: string;
+    GoogleModel: string;
+    CliCommand: string;
 }
 
 const WEEKDAY_NAMES: string[] = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
@@ -154,6 +158,89 @@ const AnalyzeWithOllama = async (data: IAiAnalysisData, url: string, model: stri
     return ExtractOllamaText(await response.json());
 };
 
+const ExtractGoogleText = (result: unknown): string => {
+    const body = result as Record<string, unknown> | null;
+    if (body === null || typeof body !== "object") throw new Error("Google API 返回格式异常");
+    const candidates = body.candidates;
+    if (!Array.isArray(candidates) || candidates.length === 0) throw new Error("Google API 返回内容为空");
+    const first = candidates[0] as Record<string, unknown> | undefined;
+    if (first === undefined || typeof first !== "object") throw new Error("Google API 返回格式异常");
+    const content = first.content as Record<string, unknown> | undefined;
+    if (content === undefined || typeof content !== "object") throw new Error("Google API 返回格式异常");
+    const parts = content.parts;
+    if (!Array.isArray(parts) || parts.length === 0) throw new Error("Google API 返回内容为空");
+    const part = parts[0] as Record<string, unknown> | undefined;
+    if (part === undefined || typeof part.text !== "string") throw new Error("Google API 返回格式异常");
+    return part.text;
+};
+
+const AnalyzeWithGoogle = async (data: IAiAnalysisData, apiKey: string, model: string): Promise<string> => {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`;
+    const response = await FetchWithTimeout(url, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "x-goog-api-key": apiKey,
+        },
+        body: JSON.stringify({
+            contents: [{ parts: [{ text: BuildPrompt(data) }] }],
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`Google API 错误: ${response.status}`);
+    }
+    return ExtractGoogleText(await response.json());
+};
+
+const CLI_TIMEOUT_MS: number = 120_000;
+
+const AnalyzeWithCli = (data: IAiAnalysisData, command: string): Promise<string> => {
+    if (command.trim() === "") {
+        throw new Error("未配置 CLI 命令");
+    }
+
+    const prompt: string = BuildPrompt(data);
+
+    return new Promise<string>((resolve, reject) => {
+        const parts: string[] = command.split(/\s+/);
+        const bin: string = parts[0]!;
+        const args: string[] = parts.slice(1);
+
+        const child = spawn(bin, args, {
+            stdio: ["pipe", "pipe", "pipe"],
+            shell: true,
+            timeout: CLI_TIMEOUT_MS,
+        });
+
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+
+        child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+        child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+
+        child.on("error", (err: Error) => {
+            reject(new Error(`CLI 启动失败: ${err.message}`));
+        });
+
+        child.on("close", (code: number | null) => {
+            const out: string = Buffer.concat(stdout).toString("utf-8").trim();
+            if (code !== 0) {
+                const errMsg: string = Buffer.concat(stderr).toString("utf-8").trim();
+                reject(new Error(`CLI 退出码 ${code ?? "null"}: ${errMsg || out || "无输出"}`));
+                return;
+            }
+            if (out === "") {
+                reject(new Error("CLI 命令无输出"));
+                return;
+            }
+            resolve(out);
+        });
+
+        child.stdin.write(prompt);
+        child.stdin.end();
+    });
+};
+
 const AnalyzeLocally = (data: IAiAnalysisData): string => {
     if (data.TotalCount === 0) {
         return "暂无数据记录，开始记录后即可获得分析洞察。";
@@ -218,8 +305,12 @@ export const Analyze = async (data: IAiAnalysisData, config: IAiConfig): Promise
             return AnalyzeWithAnthropic(data, config.ApiKey);
         case "openai":
             return AnalyzeWithOpenAi(data, config.ApiKey);
+        case "google":
+            return AnalyzeWithGoogle(data, config.ApiKey, config.GoogleModel);
         case "ollama":
             return AnalyzeWithOllama(data, config.OllamaUrl, config.OllamaModel);
+        case "cli":
+            return AnalyzeWithCli(data, config.CliCommand);
         case "local":
             return AnalyzeLocally(data);
     }

--- a/src/main/community.ts
+++ b/src/main/community.ts
@@ -1,0 +1,74 @@
+// 社区匿名统计 HTTP 客户端
+
+interface ICommunityStatsResponse {
+    WeekId: string;
+    MedianCount: number;
+    MedianDuration: number;
+    SampleSize: number;
+}
+
+interface ISubmitPayload {
+    ContributorId: string;
+    WeekId: string;
+    Count: number;
+    AvgDuration: number;
+}
+
+// ISO 8601 标准周：周一起始，第一周包含该年第一个周四
+export function GetCurrentWeekId(): string {
+    const now = new Date();
+    const d = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const weekNo: number = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+    return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+export class CommunityService {
+    private readonly _apiEndpoint: string;
+    private readonly _timeoutMs: number = 8000;
+
+    public constructor(apiEndpoint: string) {
+        this._apiEndpoint = apiEndpoint.replace(/\/+$/, "");
+    }
+
+    public async SubmitStats(
+        contributorId: string,
+        weekId: string,
+        count: number,
+        avgDuration: number
+    ): Promise<boolean> {
+        const payload: ISubmitPayload = {
+            ContributorId: contributorId,
+            WeekId: weekId,
+            Count: count,
+            AvgDuration: avgDuration,
+        };
+
+        try {
+            const response: Response = await fetch(`${this._apiEndpoint}/api/submit`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+                signal: AbortSignal.timeout(this._timeoutMs),
+            });
+            return response.ok;
+        } catch {
+            return false;
+        }
+    }
+
+    public async GetCommunityStats(weekId: string): Promise<ICommunityStatsResponse | null> {
+        try {
+            const response: Response = await fetch(
+                `${this._apiEndpoint}/api/community?weekId=${encodeURIComponent(weekId)}`,
+                { signal: AbortSignal.timeout(this._timeoutMs) }
+            );
+            if (!response.ok) return null;
+            const data: ICommunityStatsResponse = await response.json() as ICommunityStatsResponse;
+            return data;
+        } catch {
+            return null;
+        }
+    }
+}

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import path from "node:path";
+import { app } from "electron";
+import { randomUUID } from "node:crypto";
+
+interface IConfigData {
+    CommunityOptIn: boolean;
+    ContributorId: string | null;
+    ApiEndpoint: string;
+}
+
+const DEFAULT_API_ENDPOINT = "https://dickhelper-api.your-worker.workers.dev";
+
+const DEFAULT_CONFIG: IConfigData = {
+    CommunityOptIn: false,
+    ContributorId: null,
+    ApiEndpoint: DEFAULT_API_ENDPOINT,
+};
+
+export class ConfigService {
+    private _config: IConfigData;
+    private readonly _configPath: string;
+
+    public constructor() {
+        this._configPath = path.join(app.getPath("userData"), "config.json");
+        this._config = this._load();
+    }
+
+    private _load(): IConfigData {
+        if (!fs.existsSync(this._configPath)) {
+            return { ...DEFAULT_CONFIG };
+        }
+        try {
+            const raw: string = fs.readFileSync(this._configPath, "utf-8");
+            const parsed: Partial<IConfigData> = JSON.parse(raw);
+            return {
+                CommunityOptIn: typeof parsed.CommunityOptIn === "boolean" ? parsed.CommunityOptIn : DEFAULT_CONFIG.CommunityOptIn,
+                ContributorId: typeof parsed.ContributorId === "string" ? parsed.ContributorId : DEFAULT_CONFIG.ContributorId,
+                ApiEndpoint: typeof parsed.ApiEndpoint === "string" ? parsed.ApiEndpoint : DEFAULT_CONFIG.ApiEndpoint,
+            };
+        } catch {
+            return { ...DEFAULT_CONFIG };
+        }
+    }
+
+    private _save(): void {
+        fs.writeFileSync(this._configPath, JSON.stringify(this._config, null, 2), "utf-8");
+    }
+
+    public GetConfig(): IConfigData {
+        return { ...this._config };
+    }
+
+    // 仅允许设置 CommunityOptIn，ApiEndpoint 不通过 IPC 暴露
+    public SetConfig(partial: { CommunityOptIn?: boolean }): IConfigData {
+        if (partial.CommunityOptIn !== undefined) {
+            this._config.CommunityOptIn = partial.CommunityOptIn;
+            // 首次 opt-in 时生成 contributorId
+            if (partial.CommunityOptIn && this._config.ContributorId === null) {
+                this._config.ContributorId = randomUUID();
+            }
+        }
+        this._save();
+        return { ...this._config };
+    }
+}

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock electron and fs before importing DatabaseService
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/test" },
+}));
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: () => false,
+    writeFileSync: vi.fn(),
+  },
+}));
+vi.mock("node:crypto", async () => {
+  let counter = 0;
+  return {
+    randomUUID: () => `test-uuid-${++counter}`,
+  };
+});
+
+import { DatabaseService } from "./database";
+
+describe("DatabaseService", () => {
+  let db: DatabaseService;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-20T12:00:00Z"));
+    vi.clearAllMocks();
+    db = await DatabaseService.create();
+  });
+
+  afterEach(() => {
+    db.Close();
+    vi.useRealTimers();
+  });
+
+  describe("create", () => {
+    it("初始化空数据库，无记录", () => {
+      expect(db.GetRecords()).toEqual([]);
+    });
+  });
+
+  describe("SaveRecord", () => {
+    it("保存记录并返回正确字段", () => {
+      const start = new Date("2026-01-01T10:00:00Z");
+      const end = new Date("2026-01-01T10:05:00Z");
+
+      const record = db.SaveRecord(start, end, 5, "test note");
+
+      expect(record.Id).toBeTruthy();
+      expect(record.StartTime).toBe(start.toISOString());
+      expect(record.EndTime).toBe(end.toISOString());
+      expect(record.Duration).toBe(5);
+      expect(record.Notes).toBe("test note");
+    });
+
+    it("Notes 为空时存 null", () => {
+      const record = db.SaveRecord(
+        new Date("2026-01-01T10:00:00Z"),
+        new Date("2026-01-01T10:05:00Z"),
+        5
+      );
+      expect(record.Notes).toBeNull();
+    });
+  });
+
+  describe("GetRecords", () => {
+    it("按 EndTime 降序排列", () => {
+      db.SaveRecord(
+        new Date("2026-01-01T10:00:00Z"),
+        new Date("2026-01-01T10:05:00Z"),
+        5
+      );
+      db.SaveRecord(
+        new Date("2026-01-02T10:00:00Z"),
+        new Date("2026-01-02T10:10:00Z"),
+        10
+      );
+
+      const records = db.GetRecords();
+      expect(records).toHaveLength(2);
+      expect(records[0]!.EndTime > records[1]!.EndTime).toBe(true);
+    });
+  });
+
+  describe("DeleteRecord", () => {
+    it("删除存在的记录返回 true", () => {
+      const record = db.SaveRecord(
+        new Date("2026-01-01T10:00:00Z"),
+        new Date("2026-01-01T10:05:00Z"),
+        5
+      );
+
+      expect(db.DeleteRecord(record.Id)).toBe(true);
+      expect(db.GetRecords()).toHaveLength(0);
+    });
+
+    it("删除不存在的记录返回 false", () => {
+      expect(db.DeleteRecord("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("ClearAll", () => {
+    it("清空所有记录", () => {
+      db.SaveRecord(new Date(), new Date(), 1);
+      db.SaveRecord(new Date(), new Date(), 2);
+
+      db.ClearAll();
+      expect(db.GetRecords()).toHaveLength(0);
+    });
+  });
+
+  describe("GetStats", () => {
+    it("无记录时全部为零", () => {
+      const stats = db.GetStats();
+
+      expect(stats.TotalCount).toBe(0);
+      expect(stats.AverageDuration).toBe(0);
+      expect(stats.FrequencyPerWeek).toBe(0);
+      expect(stats.FrequencyPerMonth).toBe(0);
+    });
+
+    it("正确计算总数和平均时长", () => {
+      db.SaveRecord(new Date(), new Date(), 4);
+      db.SaveRecord(new Date(), new Date(), 6);
+
+      const stats = db.GetStats();
+      expect(stats.TotalCount).toBe(2);
+      expect(stats.AverageDuration).toBe(5);
+    });
+
+    it("正确计算周频率（过去7天内的记录）", () => {
+      // 系统时间固定在 2026-01-20T12:00:00Z
+      // 7天内的记录
+      db.SaveRecord(
+        new Date("2026-01-18T10:00:00Z"),
+        new Date("2026-01-18T10:05:00Z"),
+        5
+      );
+      db.SaveRecord(
+        new Date("2026-01-19T10:00:00Z"),
+        new Date("2026-01-19T10:05:00Z"),
+        5
+      );
+      // 7天外的记录
+      db.SaveRecord(
+        new Date("2026-01-10T10:00:00Z"),
+        new Date("2026-01-10T10:05:00Z"),
+        5
+      );
+
+      const stats = db.GetStats();
+      expect(stats.TotalCount).toBe(3);
+      expect(stats.FrequencyPerWeek).toBe(2);
+    });
+
+    it("正确计算月频率（本月内的记录）", () => {
+      // 系统时间固定在 2026-01-20，本月从 2026-01-01 开始
+      db.SaveRecord(
+        new Date("2026-01-05T10:00:00Z"),
+        new Date("2026-01-05T10:05:00Z"),
+        5
+      );
+      db.SaveRecord(
+        new Date("2026-01-15T10:00:00Z"),
+        new Date("2026-01-15T10:05:00Z"),
+        5
+      );
+      // 上月的记录
+      db.SaveRecord(
+        new Date("2025-12-25T10:00:00Z"),
+        new Date("2025-12-25T10:05:00Z"),
+        5
+      );
+
+      const stats = db.GetStats();
+      expect(stats.TotalCount).toBe(3);
+      expect(stats.FrequencyPerMonth).toBe(2);
+    });
+  });
+
+  describe("GetDailyCounts", () => {
+    it("返回日期范围内的每日计数", () => {
+      const day1 = new Date("2026-01-15T10:00:00Z");
+      const day2 = new Date("2026-01-16T10:00:00Z");
+
+      db.SaveRecord(day1, day1, 5);
+      db.SaveRecord(day1, day1, 3);
+      db.SaveRecord(day2, day2, 4);
+
+      const counts = db.GetDailyCounts(
+        new Date("2026-01-01T00:00:00Z").getTime(),
+        new Date("2026-01-31T23:59:59Z").getTime()
+      );
+
+      expect(counts).toHaveLength(2);
+      expect(counts[0]!.Count).toBe(2);
+      expect(counts[1]!.Count).toBe(1);
+    });
+
+    it("范围外的记录不计入", () => {
+      db.SaveRecord(
+        new Date("2026-02-01T10:00:00Z"),
+        new Date("2026-02-01T10:00:00Z"),
+        5
+      );
+
+      const counts = db.GetDailyCounts(
+        new Date("2026-01-01T00:00:00Z").getTime(),
+        new Date("2026-01-31T23:59:59Z").getTime()
+      );
+      expect(counts).toHaveLength(0);
+    });
+  });
+
+  describe("RecordExists", () => {
+    it("存在返回 true，不存在返回 false", () => {
+      const record = db.SaveRecord(new Date(), new Date(), 5);
+      expect(db.RecordExists(record.Id)).toBe(true);
+      expect(db.RecordExists("ghost")).toBe(false);
+    });
+  });
+
+  describe("ImportRecords", () => {
+    it("成功导入有效记录", () => {
+      const result = db.ImportRecords([
+        {
+          Id: "import-1",
+          StartTime: "2026-01-01T10:00:00Z",
+          EndTime: "2026-01-01T10:05:00Z",
+          Duration: 5,
+          Notes: "imported",
+        },
+      ]);
+
+      expect(result.Imported).toBe(1);
+      expect(result.Skipped).toBe(0);
+      expect(result.Rejected).toBe(0);
+      expect(db.GetRecords()).toHaveLength(1);
+    });
+
+    it("跳过重复 ID", () => {
+      db.ImportRecords([
+        { Id: "dup-1", EndTime: "2026-01-01T10:00:00Z", Duration: 5 },
+      ]);
+      const result = db.ImportRecords([
+        { Id: "dup-1", EndTime: "2026-01-01T10:00:00Z", Duration: 5 },
+      ]);
+
+      expect(result.Imported).toBe(0);
+      expect(result.Skipped).toBe(1);
+    });
+
+    it("拒绝缺少 Id 的记录", () => {
+      const result = db.ImportRecords([
+        { Id: "", EndTime: "2026-01-01T10:00:00Z", Duration: 5 },
+      ]);
+      expect(result.Rejected).toBe(1);
+      expect(result.Imported).toBe(0);
+    });
+
+    it("拒绝 Duration 为负数的记录", () => {
+      const result = db.ImportRecords([
+        { Id: "neg-1", EndTime: "2026-01-01T10:00:00Z", Duration: -1 },
+      ]);
+      expect(result.Rejected).toBe(1);
+    });
+
+    it("拒绝日期无效的记录", () => {
+      const result = db.ImportRecords([
+        { Id: "bad-date", EndTime: "not-a-date", Duration: 5 },
+      ]);
+      expect(result.Rejected).toBe(1);
+    });
+
+    it("无 StartTime 时从 EndTime - Duration 推算", () => {
+      db.ImportRecords([
+        { Id: "no-start", EndTime: "2026-01-01T10:05:00Z", Duration: 5 },
+      ]);
+
+      const records = db.GetRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]!.StartTime).toBe("2026-01-01T10:00:00.000Z");
+    });
+
+    it("旧版格式：只有 StartTime 没有 EndTime 时，StartTime 映射为 EndTime", () => {
+      db.ImportRecords([
+        { Id: "legacy-1", StartTime: "2026-01-01T10:00:00Z", Duration: 5 },
+      ]);
+
+      const records = db.GetRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]!.EndTime).toBe("2026-01-01T10:00:00.000Z");
+    });
+  });
+});

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -1,7 +1,7 @@
 import initSqlJs, { type Database, type SqlJsStatic, type BindParams, type ParamsObject } from "sql.js";
 import fs from "node:fs";
 import path from "node:path";
-import { app } from "electron";
+import { app, safeStorage } from "electron";
 import { randomUUID } from "node:crypto";
 
 // 从 SQLite 读取的原始记录类型
@@ -290,6 +290,7 @@ export class DatabaseService {
         const counts: number[] = new Array(7).fill(0) as number[];
         for (const row of rows) {
             const d = new Date((row as { EndTime: string }).EndTime);
+            // JS getDay(): 0=周日，转换为 0=周一
             const day: number = (d.getDay() + 6) % 7;
             counts[day]!++;
         }
@@ -336,6 +337,31 @@ export class DatabaseService {
     public SetSetting(key: string, value: string): void {
         this._db.run(`INSERT OR REPLACE INTO Settings (Key, Value) VALUES (?, ?)`, [key, value]);
         this._save();
+    }
+
+    /** 写入敏感设置项（使用系统密钥链加密） */
+    public SetSecureSetting(key: string, value: string): void {
+        if (value === "" || !safeStorage.isEncryptionAvailable()) {
+            this.SetSetting(key, value);
+            return;
+        }
+        const encrypted: string = safeStorage.encryptString(value).toString("base64");
+        this.SetSetting(key, `enc:${encrypted}`);
+    }
+
+    /** 读取敏感设置项（自动解密） */
+    public GetSecureSetting(key: string): string | null {
+        const raw = this.GetSetting(key);
+        if (raw === null) return null;
+        if (raw.startsWith("enc:") && safeStorage.isEncryptionAvailable()) {
+            try {
+                return safeStorage.decryptString(Buffer.from(raw.slice(4), "base64"));
+            } catch {
+                return null;
+            }
+        }
+        // 兼容未加密的旧数据
+        return raw;
     }
 
     public Close(): void {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -55,6 +55,12 @@ export class DatabaseService {
                 Notes     TEXT
             )
         `);
+        db.run(`
+            CREATE TABLE IF NOT EXISTS Settings (
+                Key   TEXT PRIMARY KEY,
+                Value TEXT NOT NULL
+            )
+        `);
         return new DatabaseService(db, dbPath);
     }
 
@@ -249,6 +255,71 @@ export class DatabaseService {
         const skipped = totalValid - imported.length;
 
         return { Imported: imported.length, Skipped: skipped, Rejected: rejected };
+    }
+
+    /** 按小时统计次数（本地时区，0-23） */
+    public GetHourlyDistribution(): { Hour: number; Count: number }[] {
+        const rows = this._queryAll(`SELECT EndTime FROM ${TABLE_NAME}`);
+        const counts: number[] = new Array(24).fill(0) as number[];
+        for (const row of rows) {
+            const d = new Date((row as { EndTime: string }).EndTime);
+            counts[d.getHours()]!++;
+        }
+        return counts.map((count, hour) => ({ Hour: hour, Count: count }));
+    }
+
+    /** 按星期统计次数（0=周一 到 6=周日） */
+    public GetWeekdayDistribution(): { Weekday: number; Count: number }[] {
+        const rows = this._queryAll(`SELECT EndTime FROM ${TABLE_NAME}`);
+        const counts: number[] = new Array(7).fill(0) as number[];
+        for (const row of rows) {
+            const d = new Date((row as { EndTime: string }).EndTime);
+            const day: number = (d.getDay() + 6) % 7;
+            counts[day]!++;
+        }
+        return counts.map((count, day) => ({ Weekday: day, Count: count }));
+    }
+
+    /** 按月统计次数（最近 12 个月） */
+    public GetMonthlyTrend(): { Month: string; Count: number }[] {
+        const now = new Date();
+        const startDate = new Date(now.getFullYear() - 1, now.getMonth(), 1);
+        const rows = this._queryAll(
+            `SELECT EndTime FROM ${TABLE_NAME} WHERE EndTime >= ?`,
+            [startDate.toISOString()]
+        );
+        const countMap = new Map<string, number>();
+        for (const row of rows) {
+            const d = new Date((row as { EndTime: string }).EndTime);
+            const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+            countMap.set(key, (countMap.get(key) ?? 0) + 1);
+        }
+        const result: { Month: string; Count: number }[] = [];
+        const cursor = new Date(startDate);
+        while (cursor <= now) {
+            const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`;
+            result.push({ Month: key, Count: countMap.get(key) ?? 0 });
+            cursor.setMonth(cursor.getMonth() + 1);
+        }
+        return result;
+    }
+
+    /** 获取所有记录的持续时长（分钟） */
+    public GetAllDurations(): number[] {
+        const rows = this._queryAll(`SELECT Duration FROM ${TABLE_NAME}`);
+        return rows.map((row) => (row as { Duration: number }).Duration);
+    }
+
+    /** 读取设置项 */
+    public GetSetting(key: string): string | null {
+        const row = this._queryOne(`SELECT Value FROM Settings WHERE Key = ?`, [key]);
+        return row !== undefined ? (row.Value as string) : null;
+    }
+
+    /** 写入设置项 */
+    public SetSetting(key: string, value: string): void {
+        this._db.run(`INSERT OR REPLACE INTO Settings (Key, Value) VALUES (?, ?)`, [key, value]);
+        this._save();
     }
 
     public Close(): void {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -134,6 +134,7 @@ export class DatabaseService {
     public GetStats(): {
         TotalCount: number;
         AverageDuration: number;
+        WeeklyAverageDuration: number;
         FrequencyPerWeek: number;
         FrequencyPerMonth: number;
     } {
@@ -150,7 +151,7 @@ export class DatabaseService {
         );
 
         const weekRow = this._queryOne(
-            `SELECT COUNT(*) as count FROM ${TABLE_NAME} WHERE EndTime >= ?`,
+            `SELECT COUNT(*) as count, AVG(Duration) as avgDur FROM ${TABLE_NAME} WHERE EndTime >= ?`,
             [oneWeekAgo.toISOString()]
         );
 
@@ -162,8 +163,23 @@ export class DatabaseService {
         return {
             TotalCount: (totalRow?.count as number) ?? 0,
             AverageDuration: (totalRow?.avgDur as number) ?? 0,
+            WeeklyAverageDuration: (weekRow?.avgDur as number) ?? 0,
             FrequencyPerWeek: (weekRow?.count as number) ?? 0,
             FrequencyPerMonth: (monthRow?.count as number) ?? 0,
+        };
+    }
+
+    // 本周统计：次数和平均时长（仅最近 7 天）
+    public GetWeeklyStats(): { Count: number; AvgDuration: number } {
+        const now = new Date();
+        const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        const row = this._queryOne(
+            `SELECT COUNT(*) as count, AVG(Duration) as avgDur FROM ${TABLE_NAME} WHERE EndTime >= ?`,
+            [oneWeekAgo.toISOString()]
+        );
+        return {
+            Count: (row?.count as number) ?? 0,
+            AvgDuration: (row?.avgDur as number) ?? 0,
         };
     }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,10 +1,14 @@
 import { app, BrowserWindow, Tray, Menu, ipcMain, nativeImage } from "electron";
 import path from "node:path";
 import { DatabaseService } from "./database";
+import { ConfigService } from "./config";
+import { CommunityService, GetCurrentWeekId } from "./community";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let databaseService: DatabaseService | null = null;
+let configService: ConfigService | null = null;
+let communityService: CommunityService | null = null;
 
 const IS_DEV: boolean = process.env.ELECTRON_RENDERER_URL !== undefined;
 
@@ -159,12 +163,46 @@ function RegisterIpcHandlers(): void {
         }
         return result;
     });
+
+    // 配置相关
+    ipcMain.handle("config:get", () => {
+        return configService!.GetConfig();
+    });
+
+    ipcMain.handle("config:set", (...args) => {
+        const partial = args[1] as { CommunityOptIn?: boolean };
+        return configService!.SetConfig(partial);
+    });
+
+    // 社区统计相关
+    ipcMain.handle("community:get-stats", async () => {
+        const weekId: string = GetCurrentWeekId();
+        return communityService!.GetCommunityStats(weekId);
+    });
+
+    ipcMain.handle("community:submit", async () => {
+        const config = configService!.GetConfig();
+        if (!config.CommunityOptIn || config.ContributorId === null) {
+            return false;
+        }
+        const weeklyStats = databaseService!.GetWeeklyStats();
+        const weekId: string = GetCurrentWeekId();
+        return communityService!.SubmitStats(
+            config.ContributorId,
+            weekId,
+            weeklyStats.Count,
+            weeklyStats.AvgDuration
+        );
+    });
 }
 
 app.whenReady().then(async () => {
     console.log("[Main] App ready");
     databaseService = await DatabaseService.create();
     console.log("[Main] DatabaseService initialized");
+    configService = new ConfigService();
+    communityService = new CommunityService(configService.GetConfig().ApiEndpoint);
+    console.log("[Main] ConfigService & CommunityService initialized");
     RegisterIpcHandlers();
     CreateWindow();
     CreateTray();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -213,9 +213,17 @@ function RegisterIpcHandlers(): void {
         return databaseService!.GetAllDurations();
     });
 
-    // 设置通道（API Key 使用系统加密存储）
+    // 设置通道（API Key 使用系统加密存储，仅允许白名单内的 key）
+    const ALLOWED_SETTINGS: Set<string> = new Set([
+        "ai_provider", "ai_api_key", "ai_ollama_url", "ai_ollama_model",
+        "ai_google_model", "ai_cli_command",
+    ]);
+
     ipcMain.handle("settings:get", (...args) => {
         const key: string = args[1] as string;
+        if (!ALLOWED_SETTINGS.has(key)) {
+            throw new Error(`不允许的设置项: ${key}`);
+        }
         if (key === "ai_api_key") {
             return databaseService!.GetSecureSetting(key);
         }
@@ -225,6 +233,9 @@ function RegisterIpcHandlers(): void {
     ipcMain.handle("settings:set", (...args) => {
         const key: string = args[1] as string;
         const value: string = args[2] as string;
+        if (!ALLOWED_SETTINGS.has(key)) {
+            throw new Error(`不允许的设置项: ${key}`);
+        }
         if (key === "ai_api_key") {
             databaseService!.SetSecureSetting(key, value);
         } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -256,7 +256,7 @@ function RegisterIpcHandlers(): void {
         };
 
         // 验证 provider 值，非法值回退到 local
-        const validProviders = ["anthropic", "openai", "ollama", "local"] as const;
+        const validProviders = ["anthropic", "openai", "google", "ollama", "cli", "local"] as const;
         const rawProvider: string = db.GetSetting("ai_provider") ?? "local";
         const provider = (validProviders as readonly string[]).includes(rawProvider)
             ? rawProvider as typeof validProviders[number]
@@ -266,6 +266,8 @@ function RegisterIpcHandlers(): void {
             ApiKey: db.GetSecureSetting("ai_api_key") ?? "",
             OllamaUrl: db.GetSetting("ai_ollama_url") ?? "http://localhost:11434",
             OllamaModel: db.GetSetting("ai_ollama_model") ?? "llama3",
+            GoogleModel: db.GetSetting("ai_google_model") ?? "gemini-2.0-flash",
+            CliCommand: db.GetSetting("ai_cli_command") ?? "",
         };
 
         try {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { DatabaseService } from "./database";
 import { ConfigService } from "./config";
 import { CommunityService, GetCurrentWeekId } from "./community";
+import { Analyze as AiAnalyze } from "./ai-service";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
@@ -193,6 +194,89 @@ function RegisterIpcHandlers(): void {
             weeklyStats.Count,
             weeklyStats.AvgDuration
         );
+    });
+
+    // 图表数据通道
+    ipcMain.handle("charts:hourly-distribution", () => {
+        return databaseService!.GetHourlyDistribution();
+    });
+
+    ipcMain.handle("charts:weekday-distribution", () => {
+        return databaseService!.GetWeekdayDistribution();
+    });
+
+    ipcMain.handle("charts:monthly-trend", () => {
+        return databaseService!.GetMonthlyTrend();
+    });
+
+    ipcMain.handle("charts:duration-distribution", () => {
+        return databaseService!.GetAllDurations();
+    });
+
+    // 设置通道（API Key 使用系统加密存储）
+    ipcMain.handle("settings:get", (...args) => {
+        const key: string = args[1] as string;
+        if (key === "ai_api_key") {
+            return databaseService!.GetSecureSetting(key);
+        }
+        return databaseService!.GetSetting(key);
+    });
+
+    ipcMain.handle("settings:set", (...args) => {
+        const key: string = args[1] as string;
+        const value: string = args[2] as string;
+        if (key === "ai_api_key") {
+            databaseService!.SetSecureSetting(key, value);
+        } else {
+            databaseService!.SetSetting(key, value);
+        }
+    });
+
+    // AI 分析通道：主进程聚合数据并调用 AI
+    ipcMain.handle("ai:analyze", async () => {
+        const db = databaseService!;
+        const stats = db.GetStats();
+        const hourly = db.GetHourlyDistribution();
+        const weekday = db.GetWeekdayDistribution();
+        const monthly = db.GetMonthlyTrend();
+        const durations = db.GetAllDurations();
+
+        const sorted = [...durations].sort((a, b) => a - b);
+        const mid: number = Math.floor(sorted.length / 2);
+        const median: number = sorted.length === 0
+            ? 0
+            : sorted.length % 2 !== 0
+                ? sorted[mid]!
+                : (sorted[mid - 1]! + sorted[mid]!) / 2;
+        const durationStats = {
+            Min: sorted[0] ?? 0,
+            Max: sorted[sorted.length - 1] ?? 0,
+            Avg: stats.AverageDuration,
+            Median: median,
+        };
+
+        // 验证 provider 值，非法值回退到 local
+        const validProviders = ["anthropic", "openai", "ollama", "local"] as const;
+        const rawProvider: string = db.GetSetting("ai_provider") ?? "local";
+        const provider = (validProviders as readonly string[]).includes(rawProvider)
+            ? rawProvider as typeof validProviders[number]
+            : "local";
+        const config = {
+            Provider: provider,
+            ApiKey: db.GetSecureSetting("ai_api_key") ?? "",
+            OllamaUrl: db.GetSetting("ai_ollama_url") ?? "http://localhost:11434",
+            OllamaModel: db.GetSetting("ai_ollama_model") ?? "llama3",
+        };
+
+        try {
+            return await AiAnalyze(
+                { ...stats, HourlyDistribution: hourly, WeekdayDistribution: weekday, MonthlyTrend: monthly, DurationStats: durationStats },
+                config
+            );
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : "分析失败";
+            throw new Error(message.length > 200 ? message.slice(0, 200) + "..." : message);
+        }
     });
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -278,7 +278,7 @@ function RegisterIpcHandlers(): void {
             OllamaUrl: db.GetSetting("ai_ollama_url") ?? "http://localhost:11434",
             OllamaModel: db.GetSetting("ai_ollama_model") ?? "llama3",
             GoogleModel: db.GetSetting("ai_google_model") ?? "gemini-2.0-flash",
-            CliCommand: db.GetSetting("ai_cli_command") ?? "",
+            CliCommand: db.GetSetting("ai_cli_command") ?? "claude -p",
         };
 
         try {

--- a/src/preload/CLAUDE.md
+++ b/src/preload/CLAUDE.md
@@ -1,0 +1,54 @@
+[根目录](../../CLAUDE.md) > [src](../) > **preload**
+
+# Preload 模块 -- 安全桥接层
+
+## 模块职责
+
+Electron 安全边界层，通过 `contextBridge.exposeInMainWorld` 将主进程 IPC 通道暴露为 `window.electronAPI`。确保渲染进程无法直接访问 Node.js API。
+
+## 入口与启动
+
+- **入口文件**：`index.ts`（构建输出为 `index.cjs`，CommonJS 格式）
+- **加载时机**：BrowserWindow 创建时通过 `webPreferences.preload` 指定
+
+## 对外接口
+
+### `window.electronAPI`
+
+| 方法 | 签名 | 说明 |
+|------|------|------|
+| `GetRecords` | `() => Promise<IRecordRaw[]>` | 获取所有记录 |
+| `SaveRecord` | `(startTime, endTime, duration, notes?) => Promise<IRecordRaw>` | 保存记录 |
+| `DeleteRecord` | `(id) => Promise<boolean>` | 删除记录 |
+| `ClearAll` | `() => Promise<void>` | 清空所有记录 |
+| `GetStats` | `() => Promise<IStats>` | 获取统计数据 |
+| `GetDailyCounts` | `(startTimestamp, endTimestamp) => Promise<IDailyCount[]>` | 获取每日计数 |
+| `ImportRecords` | `(records) => Promise<IImportResult>` | 批量导入 |
+| `OnRecordsUpdated` | `(callback) => () => void` | 监听数据更新事件，返回取消监听函数 |
+
+## 关键依赖与配置
+
+- `electron`：`contextBridge`、`ipcRenderer`
+- 构建输出格式：CommonJS（`electron.vite.config.ts` 中配置 `output.format: "cjs"`）
+
+## 数据模型
+
+类型声明在 `index.d.ts` 中，为 `window.electronAPI` 提供 TypeScript 类型支持。类型引用自 `src/renderer/types/IRecord.ts`。
+
+## 测试与质量
+
+- 无测试文件
+- 缺口：预加载脚本加载失败时仅输出 console.error，无用户可见的错误提示
+
+## 相关文件清单
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `index.ts` | 31 | contextBridge 暴露 electronAPI |
+| `index.d.ts` | 27 | window.electronAPI 全局类型声明 |
+
+## 变更记录 (Changelog)
+
+| 时间 | 操作 | 说明 |
+|------|------|------|
+| 2026-05-24 00:43:49 | 初始生成 | 首次扫描生成 |

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,5 +1,5 @@
 // 声明 window.electronAPI 类型，让渲染进程可以直接使用
-import type { IRecordRaw, IStats, IDailyCount, IImportResult } from "../renderer/types/IRecord";
+import type { IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig } from "../renderer/types/IRecord";
 
 interface IImportRecord {
     Id: string;
@@ -20,6 +20,10 @@ declare global {
             GetDailyCounts: (startTimestamp: number, endTimestamp: number) => Promise<IDailyCount[]>;
             ImportRecords: (records: IImportRecord[]) => Promise<IImportResult>;
             OnRecordsUpdated: (callback: () => void) => () => void;
+            GetConfig: () => Promise<IAppConfig>;
+            SetConfig: (partial: { CommunityOptIn?: boolean }) => Promise<IAppConfig>;
+            GetCommunityStats: () => Promise<ICommunityStats | null>;
+            SubmitCommunityStats: () => Promise<boolean>;
         };
     }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,5 +1,5 @@
 // 声明 window.electronAPI 类型，让渲染进程可以直接使用
-import type { IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig } from "../renderer/types/IRecord";
+import type { IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig, IHourlyCount, IWeekdayCount, IMonthlyCount } from "../renderer/types/IRecord";
 
 interface IImportRecord {
     Id: string;
@@ -19,6 +19,13 @@ declare global {
             GetStats: () => Promise<IStats>;
             GetDailyCounts: (startTimestamp: number, endTimestamp: number) => Promise<IDailyCount[]>;
             ImportRecords: (records: IImportRecord[]) => Promise<IImportResult>;
+            GetHourlyDistribution: () => Promise<IHourlyCount[]>;
+            GetWeekdayDistribution: () => Promise<IWeekdayCount[]>;
+            GetMonthlyTrend: () => Promise<IMonthlyCount[]>;
+            GetDurationDistribution: () => Promise<number[]>;
+            GetSetting: (key: string) => Promise<string | null>;
+            SetSetting: (key: string, value: string) => Promise<void>;
+            RequestAiAnalysis: () => Promise<string>;
             OnRecordsUpdated: (callback: () => void) => () => void;
             GetConfig: () => Promise<IAppConfig>;
             SetConfig: (partial: { CommunityOptIn?: boolean }) => Promise<IAppConfig>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,12 @@ const electronAPI = {
             ipcRenderer.removeListener("records-updated", listener);
         };
     },
+    // 配置
+    GetConfig: (): Promise<unknown> => ipcRenderer.invoke("config:get"),
+    SetConfig: (partial: { CommunityOptIn?: boolean }): Promise<unknown> => ipcRenderer.invoke("config:set", partial),
+    // 社区统计
+    GetCommunityStats: (): Promise<unknown> => ipcRenderer.invoke("community:get-stats"),
+    SubmitCommunityStats: (): Promise<boolean> => ipcRenderer.invoke("community:submit"),
 };
 
 try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,13 @@ const electronAPI = {
     GetDailyCounts: (startTimestamp: number, endTimestamp: number): Promise<unknown[]> =>
         ipcRenderer.invoke("records:get-daily-counts", startTimestamp, endTimestamp),
     ImportRecords: (records: unknown[]): Promise<unknown> => ipcRenderer.invoke("records:import", records),
+    GetHourlyDistribution: (): Promise<unknown[]> => ipcRenderer.invoke("charts:hourly-distribution"),
+    GetWeekdayDistribution: (): Promise<unknown[]> => ipcRenderer.invoke("charts:weekday-distribution"),
+    GetMonthlyTrend: (): Promise<unknown[]> => ipcRenderer.invoke("charts:monthly-trend"),
+    GetDurationDistribution: (): Promise<number[]> => ipcRenderer.invoke("charts:duration-distribution"),
+    GetSetting: (key: string): Promise<string | null> => ipcRenderer.invoke("settings:get", key),
+    SetSetting: (key: string, value: string): Promise<void> => ipcRenderer.invoke("settings:set", key, value),
+    RequestAiAnalysis: (): Promise<string> => ipcRenderer.invoke("ai:analyze"),
     OnRecordsUpdated: (callback: () => void): (() => void) => {
         const listener = (): void => callback();
         ipcRenderer.on("records-updated", listener);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,14 +16,18 @@ import {
     IconHistory,
     IconSettings,
     IconDroplet,
+    IconBolt,
+    IconFingerprint,
 } from "@tabler/icons-react";
 import "@mantine/core/styles.css";
 import { RecordForm } from "./views/RecordForm";
 import { StatsChart } from "./views/StatsChart";
 import { HistoryList } from "./views/HistoryList";
 import { Settings } from "./views/Settings";
+import { Prediction } from "./views/Prediction";
+import { Fingerprint } from "./views/Fingerprint";
 
-type View = "record" | "stats" | "history" | "settings";
+type View = "record" | "stats" | "history" | "prediction" | "fingerprint" | "settings";
 
 interface IErrorBoundaryProps { children: ReactNode; }
 interface IErrorBoundaryState { hasError: boolean; error: Error | null; }
@@ -79,6 +83,8 @@ const theme = createTheme({
 const NAV_ITEMS: { view: View; label: string; icon: typeof IconClock }[] = [
     { view: "record", label: "记录", icon: IconClock },
     { view: "stats", label: "统计", icon: IconChartBar },
+    { view: "prediction", label: "预测", icon: IconBolt },
+    { view: "fingerprint", label: "指纹", icon: IconFingerprint },
     { view: "history", label: "历史", icon: IconHistory },
 ];
 
@@ -133,6 +139,8 @@ export const App = () => {
                 <AppShell.Main>
                     {activeView === "record" && <RecordForm />}
                     {activeView === "stats" && <StatsChart />}
+                    {activeView === "prediction" && <Prediction />}
+                    {activeView === "fingerprint" && <Fingerprint />}
                     {activeView === "history" && <HistoryList />}
                     {activeView === "settings" && <Settings />}
                 </AppShell.Main>

--- a/src/renderer/CLAUDE.md
+++ b/src/renderer/CLAUDE.md
@@ -1,0 +1,135 @@
+[根目录](../../CLAUDE.md) > [src](../) > **renderer**
+
+# Renderer 模块 -- React UI 层
+
+## 模块职责
+
+Electron 渲染进程，提供用户界面。基于 React 19 + Mantine 7 组件库构建，使用 `useState` 实现视图切换（无路由库），通过 `window.electronAPI` 与主进程通信。
+
+## 入口与启动
+
+- **HTML 入口**：`index.html`（electron-vite 自动处理）
+- **React 入口**：`main.tsx` -> `App.tsx`
+- **启动流程**：
+  1. `main.tsx`：`createRoot` 挂载 `<App />`
+  2. `App.tsx`：`MantineProvider` 包裹 + `AppShell` 布局 + 四个视图切换
+
+## 对外接口
+
+本模块是终端 UI 层，不对外暴露 API。通过 `window.electronAPI`（Preload 层）调用主进程服务。
+
+## 子模块结构
+
+### views/ -- 视图组件
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `RecordForm.tsx` | 138 | 计时器界面：开始/暂停/继续/停止 + 备注输入 |
+| `StatsChart.tsx` | 257 | 统计面板：4 个统计卡片 + 4 周热力图 |
+| `HistoryList.tsx` | 131 | 历史记录列表：浏览、删除单条、清空全部（带确认弹窗） |
+| `Settings.tsx` | 156 | 设置页面：数据导入/导出 + 应用信息展示 |
+
+### hooks/ -- React Hooks
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `useRecords.ts` | 45 | 记录数据加载 Hook，监听 `records-updated` IPC 事件自动刷新 |
+| `useTimer.ts` | 131 | 计时器逻辑 Hook：Start/Pause/Resume/Stop，支持暂停时间累计扣除 |
+
+### services/ -- 服务层
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `DatabaseService.ts` | 144 | IPC 调用封装：ISO 字符串与 Date 转换、JSON 导入导出（兼容旧版格式） |
+
+### types/ -- 类型定义
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `IRecord.ts` | 37 | 共享接口：`IRecord`、`IRecordRaw`、`IStats`、`IDailyCount`、`IImportResult` |
+
+## 关键依赖与配置
+
+| 依赖 | 用途 |
+|------|------|
+| `react` / `react-dom` | UI 框架 |
+| `@mantine/core` / `@mantine/hooks` | 组件库 |
+| `@tabler/icons-react` | 图标 |
+
+- 主题字体：思源黑体 / Noto Sans SC
+- 默认圆角：`md`
+- 侧边栏宽度：220px
+
+## 数据模型
+
+### IRecord（UI 层使用，Date 对象）
+
+```typescript
+interface IRecord {
+    readonly Id: string;
+    readonly StartTime: Date;
+    readonly EndTime: Date;
+    readonly Duration: number;    // 分钟
+    readonly Notes?: string;
+}
+```
+
+### IRecordRaw（IPC 传输用，ISO 字符串）
+
+```typescript
+interface IRecordRaw {
+    readonly Id: string;
+    readonly StartTime: string;   // ISO 8601
+    readonly EndTime: string;     // ISO 8601
+    readonly Duration: number;
+    readonly Notes: string | null;
+}
+```
+
+### 导入格式兼容
+
+`DatabaseService.ImportFromJson` 支持两种格式：
+- **旧版**：JSON 数组，字段为小驼峰（`id`、`startTime`、`duration`），其中 `startTime` 实际是结束时间
+- **新版**：`{ version: 1, records: [...] }`，字段为 PascalCase（`Id`、`StartTime`、`EndTime`、`Duration`）
+
+## 测试与质量
+
+- 无测试文件
+- ErrorBoundary 组件捕获渲染错误，显示错误信息和重载按钮
+- 缺口：无组件测试、无 Hook 测试、无导入导出逻辑测试
+
+## 常见问题 (FAQ)
+
+**Q: 如何新增一个视图？**
+1. 在 `views/` 下创建 `.tsx` 文件
+2. 在 `App.tsx` 的 `View` 类型和 `NAV_ITEMS` 数组中添加条目
+3. 在 `AppShell.Main` 的条件渲染中添加对应组件
+
+**Q: 为什么不用 React Router？**
+只有 4 个视图，`useState` 视图切换足够简单，无需引入路由库。
+
+**Q: 数据从哪里来？**
+所有数据通过 `DatabaseService`（静态方法）调用 `window.electronAPI`，最终由主进程的 SQLite 数据库提供。
+
+## 相关文件清单
+
+| 文件 | 说明 |
+|------|------|
+| `main.tsx` | React 挂载入口 |
+| `App.tsx` | 根组件、ErrorBoundary、主题、布局 |
+| `env.d.ts` | Vite 客户端类型引用 |
+| `index.html` | HTML 模板 |
+| `views/RecordForm.tsx` | 计时器 + 记录表单 |
+| `views/StatsChart.tsx` | 统计卡片 + 热力图 |
+| `views/HistoryList.tsx` | 历史记录列表 |
+| `views/Settings.tsx` | 设置：导入/导出/关于 |
+| `hooks/useRecords.ts` | 记录数据 Hook |
+| `hooks/useTimer.ts` | 计时器逻辑 Hook |
+| `services/DatabaseService.ts` | IPC 封装 + 导入导出 |
+| `types/IRecord.ts` | 共享类型定义 |
+
+## 变更记录 (Changelog)
+
+| 时间 | 操作 | 说明 |
+|------|------|------|
+| 2026-05-24 00:43:49 | 初始生成 | 首次扫描生成 |

--- a/src/renderer/hooks/useTimer.test.ts
+++ b/src/renderer/hooks/useTimer.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTimer } from "./useTimer";
+
+describe("useTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("初始状态：未录制、未暂停、0 秒", () => {
+    const { result } = renderHook(() => useTimer());
+
+    expect(result.current.IsRecording).toBe(false);
+    expect(result.current.IsPaused).toBe(false);
+    expect(result.current.ElapsedSeconds).toBe(0);
+  });
+
+  it("Start 后进入录制状态", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+
+    expect(result.current.IsRecording).toBe(true);
+    expect(result.current.IsPaused).toBe(false);
+  });
+
+  it("计时器每秒递增", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => vi.advanceTimersByTime(3000));
+
+    expect(result.current.ElapsedSeconds).toBe(3);
+  });
+
+  it("Pause 暂停计时，时间停止增长", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => result.current.Pause());
+
+    expect(result.current.IsPaused).toBe(true);
+    const pausedAt = result.current.ElapsedSeconds;
+
+    act(() => vi.advanceTimersByTime(5000));
+    expect(result.current.ElapsedSeconds).toBe(pausedAt);
+  });
+
+  it("Resume 继续计时，跳过暂停时间", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => result.current.Pause());
+    act(() => vi.advanceTimersByTime(3000));
+    act(() => result.current.Resume());
+
+    expect(result.current.IsPaused).toBe(false);
+
+    act(() => vi.advanceTimersByTime(2000));
+    // 2s + 2s = 4s（暂停的3s不计入）
+    expect(result.current.ElapsedSeconds).toBe(4);
+  });
+
+  it("Stop 返回 startTime、endTime 和 durationMinutes", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => vi.advanceTimersByTime(60000));
+
+    let stopResult: ReturnType<typeof result.current.Stop> = null;
+    act(() => {
+      stopResult = result.current.Stop();
+    });
+
+    expect(stopResult).not.toBeNull();
+    expect(stopResult!.startTime).toBeInstanceOf(Date);
+    expect(stopResult!.endTime).toBeInstanceOf(Date);
+    expect(stopResult!.durationMinutes).toBeCloseTo(1, 1);
+  });
+
+  it("Stop 后状态重置", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => { result.current.Stop(); });
+
+    expect(result.current.IsRecording).toBe(false);
+    expect(result.current.IsPaused).toBe(false);
+    expect(result.current.ElapsedSeconds).toBe(0);
+  });
+
+  it("未开始时 Stop 返回 null", () => {
+    const { result } = renderHook(() => useTimer());
+
+    let stopResult: ReturnType<typeof result.current.Stop> = null;
+    act(() => {
+      stopResult = result.current.Stop();
+    });
+
+    expect(stopResult).toBeNull();
+  });
+
+  it("未录制时 Pause 无效", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Pause());
+    expect(result.current.IsPaused).toBe(false);
+  });
+
+  it("未暂停时 Resume 无效", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => result.current.Resume());
+    expect(result.current.IsPaused).toBe(false);
+  });
+
+  it("Stop 时暂停中，暂停时间正确扣除", () => {
+    const { result } = renderHook(() => useTimer());
+
+    act(() => result.current.Start());
+    act(() => vi.advanceTimersByTime(10000));
+    act(() => result.current.Pause());
+    act(() => vi.advanceTimersByTime(5000));
+
+    let stopResult: ReturnType<typeof result.current.Stop> = null;
+    act(() => {
+      stopResult = result.current.Stop();
+    });
+
+    // 10s 活跃 + 5s 暂停 = 10s 有效，约 0.17 分钟
+    expect(stopResult!.durationMinutes).toBeCloseTo(10 / 60, 1);
+  });
+});

--- a/src/renderer/services/DatabaseService.ts
+++ b/src/renderer/services/DatabaseService.ts
@@ -1,4 +1,4 @@
-import type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig } from "../types/IRecord";
+import type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig, IHourlyCount, IWeekdayCount, IMonthlyCount } from "../types/IRecord";
 
 // 检查 electronAPI 是否可用，不在 Electron 环境时给出明确错误
 function GetApi(): Window["electronAPI"] {
@@ -123,6 +123,34 @@ export class DatabaseService {
             })),
         };
         return JSON.stringify(exportData, null, 2);
+    }
+
+    public static async GetHourlyDistribution(): Promise<IHourlyCount[]> {
+        return GetApi().GetHourlyDistribution();
+    }
+
+    public static async GetWeekdayDistribution(): Promise<IWeekdayCount[]> {
+        return GetApi().GetWeekdayDistribution();
+    }
+
+    public static async GetMonthlyTrend(): Promise<IMonthlyCount[]> {
+        return GetApi().GetMonthlyTrend();
+    }
+
+    public static async GetDurationDistribution(): Promise<number[]> {
+        return GetApi().GetDurationDistribution();
+    }
+
+    public static async GetSetting(key: string): Promise<string | null> {
+        return GetApi().GetSetting(key);
+    }
+
+    public static async SetSetting(key: string, value: string): Promise<void> {
+        return GetApi().SetSetting(key, value);
+    }
+
+    public static async RequestAiAnalysis(): Promise<string> {
+        return GetApi().RequestAiAnalysis();
     }
 
     /**

--- a/src/renderer/services/DatabaseService.ts
+++ b/src/renderer/services/DatabaseService.ts
@@ -1,4 +1,4 @@
-import type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult } from "../types/IRecord";
+import type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig } from "../types/IRecord";
 
 // 检查 electronAPI 是否可用，不在 Electron 环境时给出明确错误
 function GetApi(): Window["electronAPI"] {
@@ -130,6 +130,22 @@ export class DatabaseService {
      */
     public static OnRecordsUpdated(callback: () => void): () => void {
         return GetApi().OnRecordsUpdated(callback);
+    }
+
+    public static async GetConfig(): Promise<IAppConfig> {
+        return GetApi().GetConfig();
+    }
+
+    public static async SetConfig(partial: { CommunityOptIn?: boolean }): Promise<IAppConfig> {
+        return GetApi().SetConfig(partial);
+    }
+
+    public static async GetCommunityStats(): Promise<ICommunityStats | null> {
+        return GetApi().GetCommunityStats();
+    }
+
+    public static async SubmitCommunityStats(): Promise<boolean> {
+        return GetApi().SubmitCommunityStats();
     }
 
     private static MapRawToRecord(raw: IRecordRaw): IRecord {

--- a/src/renderer/services/FingerprintService.ts
+++ b/src/renderer/services/FingerprintService.ts
@@ -1,0 +1,243 @@
+import type { IRecord } from "../types/IRecord";
+
+export interface IFingerprintConfig {
+    readonly Size: number;           // canvas 尺寸 (正方形)
+    readonly BackgroundColor: string;
+    readonly RingCount: number;       // 同心环数量
+    readonly RingBaseColor: string;   // 环底色
+}
+
+const DEFAULT_CONFIG: IFingerprintConfig = {
+    Size: 400,
+    BackgroundColor: "#0a0a1a",
+    RingCount: 5,
+    RingBaseColor: "rgba(255, 255, 255, 0.03)",
+};
+
+const DAY_COLORS: string[] = [
+    "hsl(210, 90%, 60%)",  // 周一 蓝
+    "hsl(170, 80%, 55%)",  // 周二 青
+    "hsl(140, 70%, 50%)",  // 周三 绿
+    "hsl(50, 85%, 55%)",   // 周四 黄
+    "hsl(25, 90%, 55%)",   // 周五 橙
+    "hsl(340, 85%, 60%)",  // 周六 粉
+    "hsl(280, 75%, 60%)",  // 周日 紫
+];
+
+export class FingerprintService {
+    public static Render(
+        canvas: HTMLCanvasElement,
+        records: IRecord[],
+        config: Partial<IFingerprintConfig> = {}
+    ): void {
+        const cfg = { ...DEFAULT_CONFIG, ...config };
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = cfg.Size * dpr;
+        canvas.height = cfg.Size * dpr;
+        canvas.style.width = `${cfg.Size}px`;
+        canvas.style.height = `${cfg.Size}px`;
+        ctx.scale(dpr, dpr);
+
+        const cx = cfg.Size / 2;
+        const cy = cfg.Size / 2;
+        const maxRadius = cfg.Size / 2 - 20;
+        const minRadius = maxRadius * 0.15;
+
+        // 背景
+        ctx.fillStyle = cfg.BackgroundColor;
+        ctx.fillRect(0, 0, cfg.Size, cfg.Size);
+
+        // 同心参考环
+        for (let i = 1; i <= cfg.RingCount; i++) {
+            const r = minRadius + (maxRadius - minRadius) * (i / cfg.RingCount);
+            ctx.beginPath();
+            ctx.arc(cx, cy, r, 0, Math.PI * 2);
+            ctx.strokeStyle = cfg.RingBaseColor;
+            ctx.lineWidth = 1;
+            ctx.stroke();
+        }
+
+        if (records.length === 0) {
+            FingerprintService.DrawEmptyState(ctx, cx, cy);
+            return;
+        }
+
+        // 找到时长范围用于归一化半径
+        const durations = records.map((r) => r.Duration);
+        const maxDuration = Math.max(durations.reduce((a, b) => Math.max(a, b), 0), 1);
+        const minDuration = durations.reduce((a, b) => Math.min(a, b), Infinity);
+        const durationRange = maxDuration - minDuration || 1;
+
+        // 按时间排序
+        const sorted = [...records].sort(
+            (a, b) => a.EndTime.getTime() - b.EndTime.getTime()
+        );
+
+        // 绘制连接线（相邻记录之间）
+        ctx.globalAlpha = 0.08;
+        ctx.strokeStyle = "rgba(255, 255, 255, 0.5)";
+        ctx.lineWidth = 0.5;
+        ctx.beginPath();
+        for (let i = 0; i < sorted.length; i++) {
+            const r = sorted[i]!;
+            const angle = FingerprintService.TimeToAngle(r.EndTime);
+            const radius = FingerprintService.DurationToRadius(
+                r.Duration, minDuration, durationRange, minRadius, maxRadius
+            );
+            const x = cx + Math.cos(angle) * radius;
+            const y = cy + Math.sin(angle) * radius;
+            if (i === 0) {
+                ctx.moveTo(x, y);
+            } else {
+                ctx.lineTo(x, y);
+            }
+        }
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+
+        // 绘制弧线（每条记录）
+        for (const record of sorted) {
+            FingerprintService.DrawArc(
+                ctx, cx, cy, record,
+                minDuration, durationRange, minRadius, maxRadius
+            );
+        }
+
+        // 绘制数据点（每条记录）
+        for (const record of sorted) {
+            FingerprintService.DrawDot(
+                ctx, cx, cy, record,
+                minDuration, durationRange, minRadius, maxRadius
+            );
+        }
+
+        // 中心标记
+        FingerprintService.DrawCenter(ctx, cx, cy, records.length);
+    }
+
+    public static ToDataUrl(canvas: HTMLCanvasElement): string {
+        return canvas.toDataURL("image/png");
+    }
+
+    private static TimeToAngle(date: Date): number {
+        const hours = date.getHours() + date.getMinutes() / 60;
+        return (hours / 24) * Math.PI * 2 - Math.PI / 2;
+    }
+
+    private static DurationToRadius(
+        duration: number,
+        minDuration: number,
+        durationRange: number,
+        minRadius: number,
+        maxRadius: number
+    ): number {
+        const normalized = (duration - minDuration) / durationRange;
+        return minRadius + normalized * (maxRadius - minRadius);
+    }
+
+    private static DrawArc(
+        ctx: CanvasRenderingContext2D,
+        cx: number,
+        cy: number,
+        record: IRecord,
+        minDuration: number,
+        durationRange: number,
+        minRadius: number,
+        maxRadius: number
+    ): void {
+        const angle = FingerprintService.TimeToAngle(record.EndTime);
+        const radius = FingerprintService.DurationToRadius(
+            record.Duration, minDuration, durationRange, minRadius, maxRadius
+        );
+        const dayIndex = (record.EndTime.getDay() + 6) % 7;
+        const color = DAY_COLORS[dayIndex]!;
+
+        // 弧线长度与时长正相关
+        const arcLength = Math.min(Math.PI / 4, (record.Duration / 60) * Math.PI / 6);
+
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius, angle - arcLength / 2, angle + arcLength / 2);
+        ctx.strokeStyle = color;
+        ctx.globalAlpha = 0.4;
+        ctx.lineWidth = 2;
+        ctx.lineCap = "round";
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+    }
+
+    private static DrawDot(
+        ctx: CanvasRenderingContext2D,
+        cx: number,
+        cy: number,
+        record: IRecord,
+        minDuration: number,
+        durationRange: number,
+        minRadius: number,
+        maxRadius: number
+    ): void {
+        const angle = FingerprintService.TimeToAngle(record.EndTime);
+        const radius = FingerprintService.DurationToRadius(
+            record.Duration, minDuration, durationRange, minRadius, maxRadius
+        );
+        const x = cx + Math.cos(angle) * radius;
+        const y = cy + Math.sin(angle) * radius;
+        const dayIndex = (record.EndTime.getDay() + 6) % 7;
+        const color = DAY_COLORS[dayIndex]!;
+        const dotSize = 2 + (record.Duration / 60) * 2;
+
+        // 外发光
+        const gradient = ctx.createRadialGradient(x, y, 0, x, y, dotSize * 3);
+        gradient.addColorStop(0, color.replace(/^hsl\(/, "hsla(").replace(/\)$/, ", 0.3)"));
+        gradient.addColorStop(1, "transparent");
+        ctx.beginPath();
+        ctx.arc(x, y, dotSize * 3, 0, Math.PI * 2);
+        ctx.fillStyle = gradient;
+        ctx.fill();
+
+        // 实心点
+        ctx.beginPath();
+        ctx.arc(x, y, dotSize, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.globalAlpha = 0.8;
+        ctx.fill();
+        ctx.globalAlpha = 1;
+    }
+
+    private static DrawCenter(
+        ctx: CanvasRenderingContext2D,
+        cx: number,
+        cy: number,
+        count: number
+    ): void {
+        // 中心圆
+        const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, 25);
+        gradient.addColorStop(0, "rgba(100, 150, 255, 0.3)");
+        gradient.addColorStop(1, "transparent");
+        ctx.beginPath();
+        ctx.arc(cx, cy, 25, 0, Math.PI * 2);
+        ctx.fillStyle = gradient;
+        ctx.fill();
+
+        // 计数文字
+        ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
+        ctx.font = "bold 14px sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(String(count), cx, cy);
+    }
+
+    private static DrawEmptyState(
+        ctx: CanvasRenderingContext2D,
+        cx: number,
+        cy: number
+    ): void {
+        ctx.fillStyle = "rgba(255, 255, 255, 0.3)";
+        ctx.font = "14px sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText("暂无数据", cx, cy);
+    }
+}

--- a/src/renderer/services/PredictionService.ts
+++ b/src/renderer/services/PredictionService.ts
@@ -1,0 +1,187 @@
+import type { IRecord } from "../types/IRecord";
+
+// 预测结果
+export interface IPrediction {
+    readonly Probability: number;        // 今日总概率 0-100
+    readonly PeakHour: number;           // 最高概率时段 0-23
+    readonly PeakProbability: number;    // 峰值概率 0-100
+    readonly HourlyCurve: number[];      // 24 小时概率曲线 [0-100] x 24
+    readonly WeeklyCurve: number[];      // 星期几概率 [0-100] x 7 (周一=0)
+    readonly DaysSinceLast: number;      // 距上次天数
+    readonly AverageInterval: number;    // 平均间隔天数
+    readonly NextEstimate: Date | null;  // 预计下次时间
+    readonly Streak: number;             // 当前连续天数（有记录）
+}
+
+export class PredictionService {
+    public static Analyze(records: IRecord[]): IPrediction {
+        if (records.length === 0) {
+            return PredictionService.EmptyPrediction();
+        }
+
+        const sorted = [...records].sort(
+            (a, b) => a.EndTime.getTime() - b.EndTime.getTime()
+        );
+
+        const hourlyCurve = PredictionService.CalcHourlyCurve(sorted);
+        const weeklyCurve = PredictionService.CalcWeeklyCurve(sorted);
+        const { averageInterval, daysSinceLast } = PredictionService.CalcIntervals(sorted);
+        const streak = PredictionService.CalcStreak(sorted);
+
+        const intervalFactor = PredictionService.IntervalProbability(daysSinceLast, averageInterval);
+        const now = new Date();
+        const currentHour = now.getHours();
+        const currentDay = (now.getDay() + 6) % 7; // 周一=0
+
+        const hourFactor = hourlyCurve[currentHour]! / Math.max(hourlyCurve.reduce((a, b) => Math.max(a, b), 0), 1);
+        const dayFactor = weeklyCurve[currentDay]! / Math.max(weeklyCurve.reduce((a, b) => Math.max(a, b), 0), 1);
+
+        const probability = Math.min(100, Math.round(
+            intervalFactor * 0.5 + (hourFactor * 100) * 0.25 + (dayFactor * 100) * 0.25
+        ));
+
+        const peakHour = hourlyCurve.indexOf(hourlyCurve.reduce((a, b) => Math.max(a, b), 0));
+        const peakProbability = hourlyCurve[peakHour]!;
+
+        const nextEstimate = PredictionService.EstimateNext(sorted, averageInterval, peakHour);
+
+        return {
+            Probability: probability,
+            PeakHour: peakHour,
+            PeakProbability: peakProbability,
+            HourlyCurve: hourlyCurve,
+            WeeklyCurve: weeklyCurve,
+            DaysSinceLast: daysSinceLast,
+            AverageInterval: averageInterval,
+            NextEstimate: nextEstimate,
+            Streak: streak,
+        };
+    }
+
+    private static CalcHourlyCurve(records: IRecord[]): number[] {
+        const counts = new Array<number>(24).fill(0);
+        for (const r of records) {
+            counts[r.EndTime.getHours()]!++;
+        }
+        const max = Math.max(counts.reduce((a, b) => Math.max(a, b), 0), 1);
+        return counts.map((c) => Math.round((c / max) * 100));
+    }
+
+    private static CalcWeeklyCurve(records: IRecord[]): number[] {
+        const counts = new Array<number>(7).fill(0);
+        for (const r of records) {
+            const day = (r.EndTime.getDay() + 6) % 7; // 周一=0
+            counts[day]!++;
+        }
+        const max = Math.max(counts.reduce((a, b) => Math.max(a, b), 0), 1);
+        return counts.map((c) => Math.round((c / max) * 100));
+    }
+
+    private static CalcIntervals(sorted: IRecord[]): {
+        averageInterval: number;
+        daysSinceLast: number;
+    } {
+        const now = new Date();
+        const last = sorted[sorted.length - 1]!;
+        const daysSinceLast = (now.getTime() - last.EndTime.getTime()) / (1000 * 60 * 60 * 24);
+
+        if (sorted.length < 2) {
+            return { averageInterval: 1, daysSinceLast: Math.max(0, daysSinceLast) };
+        }
+
+        // 用最近 30 条记录算间隔更有代表性
+        const recent = sorted.slice(-30);
+        let totalInterval = 0;
+        for (let i = 1; i < recent.length; i++) {
+            totalInterval += (recent[i]!.EndTime.getTime() - recent[i - 1]!.EndTime.getTime());
+        }
+        const avgMs = totalInterval / (recent.length - 1);
+        const averageInterval = Math.max(0.1, avgMs / (1000 * 60 * 60 * 24));
+
+        return { averageInterval, daysSinceLast: Math.max(0, daysSinceLast) };
+    }
+
+    private static IntervalProbability(daysSince: number, avgInterval: number): number {
+        // 距上次越久，概率越高，超过平均间隔后趋近 100
+        const ratio = daysSince / avgInterval;
+        // sigmoid 变换，ratio=1 时约 73%，ratio=2 时约 95%
+        const p = 100 / (1 + Math.exp(-2.5 * (ratio - 0.8)));
+        return Math.min(100, Math.round(p));
+    }
+
+    private static CalcStreak(sorted: IRecord[]): number {
+        if (sorted.length === 0) return 0;
+
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        let streak = 0;
+        let checkDate = new Date(today);
+
+        // 如果今天没有记录，从昨天开始算
+        const lastRecord = sorted[sorted.length - 1]!;
+        const lastDate = new Date(lastRecord.EndTime);
+        lastDate.setHours(0, 0, 0, 0);
+        if (lastDate.getTime() < today.getTime()) {
+            checkDate.setDate(checkDate.getDate() - 1);
+        }
+
+        for (let i = sorted.length - 1; i >= 0; i--) {
+            const recordDate = new Date(sorted[i]!.EndTime);
+            recordDate.setHours(0, 0, 0, 0);
+
+            if (recordDate.getTime() === checkDate.getTime()) {
+                streak++;
+                checkDate.setDate(checkDate.getDate() - 1);
+                // 跳过同一天的多条记录
+                while (i > 0) {
+                    const prev = new Date(sorted[i - 1]!.EndTime);
+                    prev.setHours(0, 0, 0, 0);
+                    if (prev.getTime() === recordDate.getTime()) {
+                        i--;
+                    } else {
+                        break;
+                    }
+                }
+            } else if (recordDate.getTime() < checkDate.getTime()) {
+                break;
+            }
+        }
+        return streak;
+    }
+
+    private static EstimateNext(
+        sorted: IRecord[],
+        avgInterval: number,
+        peakHour: number
+    ): Date | null {
+        if (sorted.length === 0) return null;
+
+        const last = sorted[sorted.length - 1]!;
+        const estimate = new Date(last.EndTime.getTime() + avgInterval * 24 * 60 * 60 * 1000);
+        estimate.setHours(peakHour, 0, 0, 0);
+
+        // 如果预测时间已过，推到明天同一时段
+        if (estimate.getTime() < Date.now()) {
+            const tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+            tomorrow.setHours(peakHour, 0, 0, 0);
+            return tomorrow;
+        }
+        return estimate;
+    }
+
+    private static EmptyPrediction(): IPrediction {
+        return {
+            Probability: 0,
+            PeakHour: 0,
+            PeakProbability: 0,
+            HourlyCurve: new Array<number>(24).fill(0),
+            WeeklyCurve: new Array<number>(7).fill(0),
+            DaysSinceLast: 0,
+            AverageInterval: 0,
+            NextEstimate: null,
+            Streak: 0,
+        };
+    }
+}

--- a/src/renderer/types/IRecord.ts
+++ b/src/renderer/types/IRecord.ts
@@ -51,3 +51,21 @@ export interface IAppConfig {
     readonly ContributorId: string | null;
     readonly ApiEndpoint: string;
 }
+
+// 小时分布（用于雷达图）
+export interface IHourlyCount {
+    readonly Hour: number;
+    readonly Count: number;
+}
+
+// 星期分布（用于柱状图）
+export interface IWeekdayCount {
+    readonly Weekday: number;
+    readonly Count: number;
+}
+
+// 月度计数（用于趋势图）
+export interface IMonthlyCount {
+    readonly Month: string;
+    readonly Count: number;
+}

--- a/src/renderer/types/IRecord.ts
+++ b/src/renderer/types/IRecord.ts
@@ -19,6 +19,7 @@ export interface IRecordRaw {
 export interface IStats {
     readonly TotalCount: number;
     readonly AverageDuration: number;
+    readonly WeeklyAverageDuration: number;
     readonly FrequencyPerWeek: number;
     readonly FrequencyPerMonth: number;
 }
@@ -34,4 +35,19 @@ export interface IImportResult {
     readonly Imported: number;
     readonly Skipped: number;
     readonly Rejected: number;
+}
+
+// 社区聚合统计
+export interface ICommunityStats {
+    readonly WeekId: string;
+    readonly MedianCount: number;
+    readonly MedianDuration: number;
+    readonly SampleSize: number;
+}
+
+// 应用配置
+export interface IAppConfig {
+    readonly CommunityOptIn: boolean;
+    readonly ContributorId: string | null;
+    readonly ApiEndpoint: string;
 }

--- a/src/renderer/views/Fingerprint.tsx
+++ b/src/renderer/views/Fingerprint.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Paper, Title, Stack, Text, Group, Button, Badge, SimpleGrid, Box } from "@mantine/core";
+import { IconDownload, IconRefresh } from "@tabler/icons-react";
+import { DatabaseService } from "../services/DatabaseService";
+import { FingerprintService } from "../services/FingerprintService";
+import type { IRecord } from "../types/IRecord";
+
+const DAY_LABELS: string[] = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
+
+const DAY_COLORS: string[] = [
+    "#4a90d9", "#45b5aa", "#4caf50",
+    "#d4a843", "#e67e22", "#e84393", "#9b59b6",
+];
+
+const CANVAS_SIZE = 400;
+
+export const Fingerprint = () => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [records, setRecords] = useState<IRecord[]>([]);
+    const [stats, setStats] = useState<{
+        total: number;
+        uniqueDays: number;
+        favoriteHour: number;
+        favoriteDay: number;
+    }>({ total: 0, uniqueDays: 0, favoriteHour: 0, favoriteDay: 0 });
+
+    const LoadData = useCallback(async (): Promise<void> => {
+        const data = await DatabaseService.GetRecords();
+        setRecords(data);
+        if (data.length > 0) {
+            setStats(CalcStats(data));
+        }
+    }, []);
+
+    useEffect(() => {
+        LoadData();
+        const unsubscribe = DatabaseService.OnRecordsUpdated(() => { LoadData(); });
+        return () => { unsubscribe(); };
+    }, [LoadData]);
+
+    useEffect(() => {
+        if (canvasRef.current) {
+            FingerprintService.Render(canvasRef.current, records, { Size: CANVAS_SIZE });
+        }
+    }, [records]);
+
+    const HandleDownload = (): void => {
+        if (!canvasRef.current) return;
+        const dataUrl = FingerprintService.ToDataUrl(canvasRef.current);
+        const link = document.createElement("a");
+        link.download = `dick-fingerprint-${new Date().toISOString().slice(0, 10)}.png`;
+        link.href = dataUrl;
+        link.click();
+    };
+
+    return (
+        <Stack gap="lg" maw={860} mx="auto">
+            <Stack gap={4}>
+                <Title order={3} c="blue">JB 指纹</Title>
+                <Text size="sm" c="dimmed">
+                    基于所有历史数据生成的独一无二的可视化图案。角度 = 时刻，半径 = 时长，颜色 = 星期。
+                </Text>
+            </Stack>
+
+            {/* 指纹画布 */}
+            <Paper shadow="md" radius="lg" p="xl" withBorder
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    background: "linear-gradient(135deg, #0a0a1a05, #1a1a2e08)",
+                }}
+            >
+                <canvas
+                    ref={canvasRef}
+                    style={{
+                        borderRadius: 16,
+                        maxWidth: "100%",
+                    }}
+                />
+
+                <Group mt="md" gap="sm">
+                    <Button
+                        variant="light"
+                        leftSection={<IconDownload size={16} />}
+                        onClick={HandleDownload}
+                        disabled={records.length === 0}
+                    >
+                        保存图片
+                    </Button>
+                    <Button
+                        variant="subtle"
+                        leftSection={<IconRefresh size={16} />}
+                        onClick={LoadData}
+                    >
+                        刷新
+                    </Button>
+                </Group>
+            </Paper>
+
+            {/* 图例 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Title order={4} mb="md">颜色图例</Title>
+                <Group gap="md" wrap="wrap">
+                    {DAY_LABELS.map((label, i) => (
+                        <Group key={i} gap={6}>
+                            <Box style={{
+                                width: 12, height: 12, borderRadius: 3,
+                                backgroundColor: DAY_COLORS[i],
+                            }} />
+                            <Text size="sm" c="dimmed">{label}</Text>
+                        </Group>
+                    ))}
+                </Group>
+                <Stack gap={4} mt="md">
+                    <Text size="xs" c="dimmed">角度：一天中的时刻 (顶部=0:00, 右侧=6:00, 底部=12:00, 左侧=18:00)</Text>
+                    <Text size="xs" c="dimmed">半径：时长越长越靠外圈</Text>
+                    <Text size="xs" c="dimmed">中心数字：总记录数</Text>
+                </Stack>
+            </Paper>
+
+            {/* 指纹数据摘要 */}
+            {records.length > 0 && (
+                <Paper shadow="sm" radius="md" p="lg" withBorder>
+                    <Title order={4} mb="md">指纹摘要</Title>
+                    <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="md">
+                        <Stack gap={2} align="center">
+                            <Text size="xl" fw={700} c="blue">{stats.total}</Text>
+                            <Text size="xs" c="dimmed">总数据点</Text>
+                        </Stack>
+                        <Stack gap={2} align="center">
+                            <Text size="xl" fw={700} c="cyan">{stats.uniqueDays}</Text>
+                            <Text size="xs" c="dimmed">活跃天数</Text>
+                        </Stack>
+                        <Stack gap={2} align="center">
+                            <Group gap={4}>
+                                <Text size="xl" fw={700} c="green">{stats.favoriteHour}:00</Text>
+                            </Group>
+                            <Text size="xs" c="dimmed">最活跃时段</Text>
+                        </Stack>
+                        <Stack gap={2} align="center">
+                            <Badge color={DAY_COLORS[stats.favoriteDay]} variant="filled" size="lg">
+                                {DAY_LABELS[stats.favoriteDay]}
+                            </Badge>
+                            <Text size="xs" c="dimmed">最活跃星期</Text>
+                        </Stack>
+                    </SimpleGrid>
+                </Paper>
+            )}
+        </Stack>
+    );
+};
+
+function CalcStats(records: IRecord[]): {
+    total: number;
+    uniqueDays: number;
+    favoriteHour: number;
+    favoriteDay: number;
+} {
+    const daySet = new Set<string>();
+    const hourCounts = new Array<number>(24).fill(0);
+    const weekdayCounts = new Array<number>(7).fill(0);
+
+    for (const r of records) {
+        const d = r.EndTime;
+        const dateKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        daySet.add(dateKey);
+        hourCounts[d.getHours()]!++;
+        weekdayCounts[(d.getDay() + 6) % 7]!++;
+    }
+
+    const favoriteHour = hourCounts.indexOf(hourCounts.reduce((a, b) => Math.max(a, b), 0));
+    const favoriteDay = weekdayCounts.indexOf(weekdayCounts.reduce((a, b) => Math.max(a, b), 0));
+
+    return {
+        total: records.length,
+        uniqueDays: daySet.size,
+        favoriteHour,
+        favoriteDay,
+    };
+}

--- a/src/renderer/views/Prediction.tsx
+++ b/src/renderer/views/Prediction.tsx
@@ -1,0 +1,270 @@
+import { useState, useEffect, useCallback } from "react";
+import { Paper, Title, Stack, Text, Group, Box, SimpleGrid, ThemeIcon, RingProgress, Badge } from "@mantine/core";
+import { IconBolt, IconClock, IconFlame, IconMoon, IconSun, IconCalendar } from "@tabler/icons-react";
+import { DatabaseService } from "../services/DatabaseService";
+import { PredictionService, type IPrediction } from "../services/PredictionService";
+import type { IRecord } from "../types/IRecord";
+
+const WEEKDAY_LABELS: string[] = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
+
+const HOUR_LABELS: string[] = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11",
+    "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23",
+];
+
+function FormatCountdown(target: Date | null): string {
+    if (!target) return "--";
+    const diff = target.getTime() - Date.now();
+    if (diff <= 0) return "随时可能";
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    if (hours >= 24) {
+        const days = Math.floor(hours / 24);
+        return `${days}天${hours % 24}小时`;
+    }
+    return `${hours}小时${minutes}分钟`;
+}
+
+function GetWeatherIcon(probability: number): typeof IconSun {
+    if (probability >= 80) return IconFlame;
+    if (probability >= 50) return IconBolt;
+    if (probability >= 30) return IconMoon;
+    return IconSun;
+}
+
+function GetWeatherLabel(probability: number): string {
+    if (probability >= 80) return "欲望暴风雨";
+    if (probability >= 50) return "蠢蠢欲动";
+    if (probability >= 30) return "微风徐徐";
+    return "风平浪静";
+}
+
+function GetWeatherColor(probability: number): string {
+    if (probability >= 80) return "red";
+    if (probability >= 50) return "orange";
+    if (probability >= 30) return "yellow";
+    return "green";
+}
+
+export const Prediction = () => {
+    const [prediction, setPrediction] = useState<IPrediction | null>(null);
+    const [countdown, setCountdown] = useState<string>("--");
+
+    const LoadData = useCallback(async (): Promise<void> => {
+        const records: IRecord[] = await DatabaseService.GetRecords();
+        const result = PredictionService.Analyze(records);
+        setPrediction(result);
+        setCountdown(FormatCountdown(result.NextEstimate));
+    }, []);
+
+    useEffect(() => {
+        LoadData();
+        const unsubscribe = DatabaseService.OnRecordsUpdated(() => { LoadData(); });
+        return () => { unsubscribe(); };
+    }, [LoadData]);
+
+    useEffect(() => {
+        if (!prediction?.NextEstimate) return;
+        setCountdown(FormatCountdown(prediction.NextEstimate));
+        const timer = window.setInterval(() => {
+            setCountdown(FormatCountdown(prediction.NextEstimate));
+        }, 60_000);
+        return () => { clearInterval(timer); };
+    }, [prediction?.NextEstimate]);
+
+    if (!prediction) return null;
+
+    const WeatherIcon = GetWeatherIcon(prediction.Probability);
+    const weatherLabel = GetWeatherLabel(prediction.Probability);
+    const weatherColor = GetWeatherColor(prediction.Probability);
+
+    return (
+        <Stack gap="lg" maw={860} mx="auto">
+            <Stack gap={4}>
+                <Title order={3} c="blue">精力预测</Title>
+                <Text size="sm" c="dimmed">基于历史数据分析你的行为模式，预测下次最可能的时间。</Text>
+            </Stack>
+
+            {/* 主预测卡片 - 天气预报风格 */}
+            <Paper shadow="md" radius="lg" p="xl" withBorder
+                style={{ background: "linear-gradient(135deg, #667eea11, #764ba211)" }}
+            >
+                <Group justify="space-between" align="center" wrap="nowrap">
+                    <Stack gap="xs">
+                        <Group gap="sm" align="center">
+                            <ThemeIcon size={48} radius="xl" variant="light" color={weatherColor}>
+                                <WeatherIcon size={28} />
+                            </ThemeIcon>
+                            <Stack gap={0}>
+                                <Text size="sm" c="dimmed" fw={500}>今日预报</Text>
+                                <Text size="lg" fw={700} c={weatherColor}>{weatherLabel}</Text>
+                            </Stack>
+                        </Group>
+                        <Group gap="lg" mt="xs">
+                            <Stack gap={0}>
+                                <Text size="xs" c="dimmed">距上次</Text>
+                                <Text fw={600}>
+                                    {prediction.DaysSinceLast < 1
+                                        ? `${Math.round(prediction.DaysSinceLast * 24)}小时`
+                                        : `${prediction.DaysSinceLast.toFixed(1)}天`
+                                    }
+                                </Text>
+                            </Stack>
+                            <Stack gap={0}>
+                                <Text size="xs" c="dimmed">平均间隔</Text>
+                                <Text fw={600}>{prediction.AverageInterval.toFixed(1)}天</Text>
+                            </Stack>
+                            <Stack gap={0}>
+                                <Text size="xs" c="dimmed">连续天数</Text>
+                                <Text fw={600}>{prediction.Streak}天</Text>
+                            </Stack>
+                        </Group>
+                    </Stack>
+
+                    <RingProgress
+                        size={120}
+                        thickness={10}
+                        roundCaps
+                        sections={[{ value: prediction.Probability, color: weatherColor }]}
+                        label={
+                            <Stack gap={0} align="center">
+                                <Text size="xl" fw={700}>{prediction.Probability}%</Text>
+                                <Text size="xs" c="dimmed">概率</Text>
+                            </Stack>
+                        }
+                    />
+                </Group>
+
+                <Paper radius="md" p="md" mt="md" withBorder bg="rgba(0,0,0,0.02)">
+                    <Group justify="space-between" align="center">
+                        <Group gap="sm">
+                            <IconClock size={18} color="gray" />
+                            <Text size="sm" c="dimmed">预计下次发射</Text>
+                        </Group>
+                        <Group gap="sm">
+                            <Text fw={600} size="lg">{countdown}</Text>
+                            {prediction.NextEstimate && (
+                                <Badge variant="light" color="blue" size="sm">
+                                    {prediction.NextEstimate.getHours()}:00
+                                </Badge>
+                            )}
+                        </Group>
+                    </Group>
+                </Paper>
+            </Paper>
+
+            {/* 24 小时欲望曲线 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Stack gap={2} mb="md">
+                    <Title order={4}>24 小时欲望曲线</Title>
+                    <Text size="sm" c="dimmed">
+                        峰值时段: {prediction.PeakHour}:00 (概率 {prediction.PeakProbability}%)
+                    </Text>
+                </Stack>
+
+                <Box style={{ position: "relative", height: 120 }}>
+                    <Group gap={1} align="flex-end" style={{ height: "100%" }} wrap="nowrap">
+                        {prediction.HourlyCurve.map((value, hour) => {
+                            const isNow = new Date().getHours() === hour;
+                            const isPeak = hour === prediction.PeakHour;
+                            return (
+                                <Box key={hour} style={{
+                                    flex: 1,
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    alignItems: "center",
+                                    height: "100%",
+                                    justifyContent: "flex-end",
+                                }}>
+                                    <Box style={{
+                                        width: "100%",
+                                        maxWidth: 16,
+                                        height: `${Math.max(2, value)}%`,
+                                        borderRadius: "4px 4px 0 0",
+                                        background: isPeak
+                                            ? "linear-gradient(180deg, #ff6b6b, #ee5a24)"
+                                            : isNow
+                                                ? "linear-gradient(180deg, #74b9ff, #0984e3)"
+                                                : `rgba(116, 185, 255, ${0.2 + value / 150})`,
+                                        transition: "height 0.3s ease",
+                                    }} />
+                                </Box>
+                            );
+                        })}
+                    </Group>
+                    <Group gap={1} mt={4} wrap="nowrap">
+                        {HOUR_LABELS.map((label, i) => (
+                            <Text key={i} size="9px" c="dimmed" ta="center" style={{ flex: 1 }}>
+                                {i % 3 === 0 ? label : ""}
+                            </Text>
+                        ))}
+                    </Group>
+                </Box>
+            </Paper>
+
+            {/* 星期热度 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Title order={4} mb="md">星期热度</Title>
+                <SimpleGrid cols={7} spacing="xs">
+                    {prediction.WeeklyCurve.map((value, day) => {
+                        const isToday = (new Date().getDay() + 6) % 7 === day;
+                        return (
+                            <Stack key={day} gap={4} align="center">
+                                <Box style={{
+                                    width: 40,
+                                    height: 40,
+                                    borderRadius: 8,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    background: `rgba(116, 185, 255, ${0.1 + value / 130})`,
+                                    border: isToday ? "2px solid #228be6" : "2px solid transparent",
+                                }}>
+                                    <Text size="sm" fw={600} c={value > 60 ? "blue" : "dimmed"}>
+                                        {value}
+                                    </Text>
+                                </Box>
+                                <Text size="xs" c={isToday ? "blue" : "dimmed"} fw={isToday ? 700 : 400}>
+                                    {WEEKDAY_LABELS[day]}
+                                </Text>
+                            </Stack>
+                        );
+                    })}
+                </SimpleGrid>
+            </Paper>
+
+            {/* 分析师建议 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Group gap="sm" mb="sm">
+                    <IconCalendar size={18} />
+                    <Title order={4}>分析师建议</Title>
+                </Group>
+                <Text size="sm" c="dimmed">
+                    {GenerateAdvice(prediction)}
+                </Text>
+            </Paper>
+        </Stack>
+    );
+};
+
+function GenerateAdvice(p: IPrediction): string {
+    if (p.Probability === 0) {
+        return "数据不足，无法分析。继续记录以获得更准确的预测。";
+    }
+
+    const parts: string[] = [];
+
+    if (p.DaysSinceLast > p.AverageInterval * 1.5) {
+        parts.push(`已超出平均间隔 ${((p.DaysSinceLast / p.AverageInterval - 1) * 100).toFixed(0)}%，近期概率较高。`);
+    } else if (p.DaysSinceLast < p.AverageInterval * 0.3) {
+        parts.push("刚刚释放不久，建议休息恢复。");
+    }
+
+    parts.push(`你最活跃的时段是 ${p.PeakHour}:00 前后，${WEEKDAY_LABELS[(new Date().getDay() + 6) % 7]} 的历史活跃度为 ${p.WeeklyCurve[(new Date().getDay() + 6) % 7]}%。`);
+
+    if (p.Streak >= 3) {
+        parts.push(`已连续 ${p.Streak} 天活跃，注意适度。`);
+    }
+
+    return parts.join(" ");
+}

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -213,7 +213,7 @@ const AiConfigSection = () => {
     const [ollamaUrl, setOllamaUrl] = useState<string>("http://localhost:11434");
     const [ollamaModel, setOllamaModel] = useState<string>("llama3");
     const [googleModel, setGoogleModel] = useState<string>("gemini-2.0-flash");
-    const [cliCommand, setCliCommand] = useState<string>("");
+    const [cliCommand, setCliCommand] = useState<string>("claude -p");
     const [saved, setSaved] = useState<boolean>(false);
     const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import {
     Paper,
     Stack,
@@ -10,16 +10,31 @@ import {
     rem,
     Divider,
     Badge,
+    Switch,
 } from "@mantine/core";
-import { IconDownload, IconUpload, IconDatabase, IconInfoCircle } from "@tabler/icons-react";
+import { IconDownload, IconUpload, IconDatabase, IconInfoCircle, IconUsers } from "@tabler/icons-react";
 import { DatabaseService } from "../services/DatabaseService";
 import { useRecords } from "../hooks/useRecords";
 
 export const Settings = () => {
     const { records, refresh } = useRecords();
     const [importMessage, setImportMessage] = useState<string | null>(null);
+    const [communityOptIn, setCommunityOptIn] = useState<boolean>(false);
+    const [configLoaded, setConfigLoaded] = useState<boolean>(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const importTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        DatabaseService.GetConfig().then((config) => {
+            setCommunityOptIn(config.CommunityOptIn);
+            setConfigLoaded(true);
+        });
+    }, []);
+
+    const HandleOptInToggle = async (checked: boolean): Promise<void> => {
+        setCommunityOptIn(checked);
+        await DatabaseService.SetConfig({ CommunityOptIn: checked });
+    };
 
     const HandleExport = async (): Promise<void> => {
         const allRecords = await DatabaseService.GetRecords();
@@ -126,6 +141,29 @@ export const Settings = () => {
                         {importMessage}
                     </Notification>
                 )}
+            </Paper>
+
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Group justify="space-between" align="flex-start" mb="xs">
+                    <Group gap="sm">
+                        <IconUsers size={22} />
+                        <Title order={4}>社区统计</Title>
+                    </Group>
+                    {configLoaded && (
+                        <Switch
+                            checked={communityOptIn}
+                            onChange={(e) => HandleOptInToggle(e.currentTarget.checked)}
+                            size="md"
+                        />
+                    )}
+                </Group>
+                <Text size="sm" c="dimmed" mb="xs">
+                    匿名参与社区聚合统计，查看你和社区平均水平的对比。
+                </Text>
+                <Text size="xs" c="dimmed">
+                    开启后仅上报本周次数和平均时长两个数字，不含任何个人信息、时间戳或记录详情。
+                    数据通过随机 ID 匿名提交，无法关联到你的身份。可随时关闭。
+                </Text>
             </Paper>
 
             <Paper shadow="sm" radius="md" p="lg" withBorder>

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -202,7 +202,9 @@ const PROVIDER_OPTIONS: { value: string; label: string }[] = [
     { value: "local", label: "本地规则分析（无需 API）" },
     { value: "anthropic", label: "Anthropic (Claude)" },
     { value: "openai", label: "OpenAI (GPT)" },
+    { value: "google", label: "Google (Gemini)" },
     { value: "ollama", label: "Ollama（本地模型）" },
+    { value: "cli", label: "本地 CLI 命令" },
 ];
 
 const AiConfigSection = () => {
@@ -210,6 +212,8 @@ const AiConfigSection = () => {
     const [apiKey, setApiKey] = useState<string>("");
     const [ollamaUrl, setOllamaUrl] = useState<string>("http://localhost:11434");
     const [ollamaModel, setOllamaModel] = useState<string>("llama3");
+    const [googleModel, setGoogleModel] = useState<string>("gemini-2.0-flash");
+    const [cliCommand, setCliCommand] = useState<string>("");
     const [saved, setSaved] = useState<boolean>(false);
     const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -218,6 +222,8 @@ const AiConfigSection = () => {
         DatabaseService.GetSetting("ai_api_key").then((v) => { if (v !== null) setApiKey(v); });
         DatabaseService.GetSetting("ai_ollama_url").then((v) => { if (v !== null) setOllamaUrl(v); });
         DatabaseService.GetSetting("ai_ollama_model").then((v) => { if (v !== null) setOllamaModel(v); });
+        DatabaseService.GetSetting("ai_google_model").then((v) => { if (v !== null) setGoogleModel(v); });
+        DatabaseService.GetSetting("ai_cli_command").then((v) => { if (v !== null) setCliCommand(v); });
         return () => {
             if (savedTimerRef.current !== null) clearTimeout(savedTimerRef.current);
         };
@@ -228,13 +234,17 @@ const AiConfigSection = () => {
         await DatabaseService.SetSetting("ai_api_key", apiKey);
         await DatabaseService.SetSetting("ai_ollama_url", ollamaUrl);
         await DatabaseService.SetSetting("ai_ollama_model", ollamaModel);
+        await DatabaseService.SetSetting("ai_google_model", googleModel);
+        await DatabaseService.SetSetting("ai_cli_command", cliCommand);
         setSaved(true);
         if (savedTimerRef.current !== null) clearTimeout(savedTimerRef.current);
         savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
     };
 
-    const showApiKey: boolean = provider === "anthropic" || provider === "openai";
+    const showApiKey: boolean = provider === "anthropic" || provider === "openai" || provider === "google";
     const showOllama: boolean = provider === "ollama";
+    const showGoogle: boolean = provider === "google";
+    const showCli: boolean = provider === "cli";
 
     return (
         <Paper shadow="sm" radius="md" p="lg" withBorder>
@@ -243,7 +253,7 @@ const AiConfigSection = () => {
                 <Title order={4}>AI 分析配置</Title>
             </Group>
             <Text size="sm" c="dimmed" mb="md">
-                选择 AI 服务商用于数据分析，本地规则分析无需配置。
+                选择 AI 服务商用于数据分析，支持云端 API、本地模型和 CLI 工具。
             </Text>
 
             <Stack gap="sm">
@@ -257,9 +267,18 @@ const AiConfigSection = () => {
                 {showApiKey && (
                     <PasswordInput
                         label="API Key"
-                        placeholder={provider === "anthropic" ? "sk-ant-..." : "sk-..."}
+                        placeholder={provider === "anthropic" ? "sk-ant-..." : provider === "google" ? "AIza..." : "sk-..."}
                         value={apiKey}
                         onChange={(e) => setApiKey(e.currentTarget.value)}
+                    />
+                )}
+
+                {showGoogle && (
+                    <TextInput
+                        label="模型名称"
+                        placeholder="gemini-2.0-flash"
+                        value={googleModel}
+                        onChange={(e) => setGoogleModel(e.currentTarget.value)}
                     />
                 )}
 
@@ -278,6 +297,16 @@ const AiConfigSection = () => {
                             onChange={(e) => setOllamaModel(e.currentTarget.value)}
                         />
                     </>
+                )}
+
+                {showCli && (
+                    <TextInput
+                        label="CLI 命令"
+                        description="提示词将通过 stdin 传入，stdout 作为分析结果。例如：claude -p"
+                        placeholder="claude -p"
+                        value={cliCommand}
+                        onChange={(e) => setCliCommand(e.currentTarget.value)}
+                    />
                 )}
 
                 <Group>

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -11,8 +11,11 @@ import {
     Divider,
     Badge,
     Switch,
+    Select,
+    TextInput,
+    PasswordInput,
 } from "@mantine/core";
-import { IconDownload, IconUpload, IconDatabase, IconInfoCircle, IconUsers } from "@tabler/icons-react";
+import { IconDownload, IconUpload, IconDatabase, IconInfoCircle, IconUsers, IconBrain } from "@tabler/icons-react";
 import { DatabaseService } from "../services/DatabaseService";
 import { useRecords } from "../hooks/useRecords";
 
@@ -88,7 +91,7 @@ export const Settings = () => {
                     设置
                 </Title>
                 <Text size="sm" c="dimmed">
-                    管理数据导入导出，并查看应用信息。
+                    管理数据导入导出、AI 分析配置，并查看应用信息。
                 </Text>
             </Stack>
 
@@ -143,6 +146,8 @@ export const Settings = () => {
                 )}
             </Paper>
 
+            <AiConfigSection />
+
             <Paper shadow="sm" radius="md" p="lg" withBorder>
                 <Group justify="space-between" align="flex-start" mb="xs">
                     <Group gap="sm">
@@ -190,5 +195,100 @@ export const Settings = () => {
                 </Stack>
             </Paper>
         </Stack>
+    );
+};
+
+const PROVIDER_OPTIONS: { value: string; label: string }[] = [
+    { value: "local", label: "本地规则分析（无需 API）" },
+    { value: "anthropic", label: "Anthropic (Claude)" },
+    { value: "openai", label: "OpenAI (GPT)" },
+    { value: "ollama", label: "Ollama（本地模型）" },
+];
+
+const AiConfigSection = () => {
+    const [provider, setProvider] = useState<string>("local");
+    const [apiKey, setApiKey] = useState<string>("");
+    const [ollamaUrl, setOllamaUrl] = useState<string>("http://localhost:11434");
+    const [ollamaModel, setOllamaModel] = useState<string>("llama3");
+    const [saved, setSaved] = useState<boolean>(false);
+    const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        DatabaseService.GetSetting("ai_provider").then((v) => { if (v !== null) setProvider(v); });
+        DatabaseService.GetSetting("ai_api_key").then((v) => { if (v !== null) setApiKey(v); });
+        DatabaseService.GetSetting("ai_ollama_url").then((v) => { if (v !== null) setOllamaUrl(v); });
+        DatabaseService.GetSetting("ai_ollama_model").then((v) => { if (v !== null) setOllamaModel(v); });
+        return () => {
+            if (savedTimerRef.current !== null) clearTimeout(savedTimerRef.current);
+        };
+    }, []);
+
+    const HandleSave = async (): Promise<void> => {
+        await DatabaseService.SetSetting("ai_provider", provider);
+        await DatabaseService.SetSetting("ai_api_key", apiKey);
+        await DatabaseService.SetSetting("ai_ollama_url", ollamaUrl);
+        await DatabaseService.SetSetting("ai_ollama_model", ollamaModel);
+        setSaved(true);
+        if (savedTimerRef.current !== null) clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
+    };
+
+    const showApiKey: boolean = provider === "anthropic" || provider === "openai";
+    const showOllama: boolean = provider === "ollama";
+
+    return (
+        <Paper shadow="sm" radius="md" p="lg" withBorder>
+            <Group gap="sm" mb="xs">
+                <IconBrain size={22} />
+                <Title order={4}>AI 分析配置</Title>
+            </Group>
+            <Text size="sm" c="dimmed" mb="md">
+                选择 AI 服务商用于数据分析，本地规则分析无需配置。
+            </Text>
+
+            <Stack gap="sm">
+                <Select
+                    label="AI 服务商"
+                    data={PROVIDER_OPTIONS}
+                    value={provider}
+                    onChange={(v) => { if (v !== null) setProvider(v); }}
+                />
+
+                {showApiKey && (
+                    <PasswordInput
+                        label="API Key"
+                        placeholder={provider === "anthropic" ? "sk-ant-..." : "sk-..."}
+                        value={apiKey}
+                        onChange={(e) => setApiKey(e.currentTarget.value)}
+                    />
+                )}
+
+                {showOllama && (
+                    <>
+                        <TextInput
+                            label="Ollama 地址"
+                            placeholder="http://localhost:11434"
+                            value={ollamaUrl}
+                            onChange={(e) => setOllamaUrl(e.currentTarget.value)}
+                        />
+                        <TextInput
+                            label="模型名称"
+                            placeholder="llama3"
+                            value={ollamaModel}
+                            onChange={(e) => setOllamaModel(e.currentTarget.value)}
+                        />
+                    </>
+                )}
+
+                <Group>
+                    <Button variant="filled" color="blue" onClick={HandleSave}>
+                        保存配置
+                    </Button>
+                    {saved && (
+                        <Text size="sm" c="green">已保存</Text>
+                    )}
+                </Group>
+            </Stack>
+        </Paper>
     );
 };

--- a/src/renderer/views/StatsChart.tsx
+++ b/src/renderer/views/StatsChart.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, type ReactNode } from "react";
-import { Paper, Title, SimpleGrid, Stack, Text, Group, Box, Tooltip, ThemeIcon } from "@mantine/core";
-import { IconChartBar, IconClock, IconDroplet, IconHistory } from "@tabler/icons-react";
+import { Paper, Title, SimpleGrid, Stack, Text, Group, Box, Tooltip, ThemeIcon, Progress, Badge } from "@mantine/core";
+import { IconChartBar, IconClock, IconDroplet, IconHistory, IconUsers } from "@tabler/icons-react";
 import { DatabaseService } from "../services/DatabaseService";
-import type { IStats, IDailyCount } from "../types/IRecord";
+import type { IStats, IDailyCount, ICommunityStats } from "../types/IRecord";
 
 const DAYS_IN_WEEK: number = 7;
 const WEEKS_TO_SHOW: number = 4;
@@ -12,10 +12,13 @@ export const StatsChart = () => {
     const [stats, setStats] = useState<IStats>({
         TotalCount: 0,
         AverageDuration: 0,
+        WeeklyAverageDuration: 0,
         FrequencyPerWeek: 0,
         FrequencyPerMonth: 0,
     });
     const [dailyCounts, setDailyCounts] = useState<Map<string, number>>(new Map());
+    const [communityStats, setCommunityStats] = useState<ICommunityStats | null>(null);
+    const [optedIn, setOptedIn] = useState<boolean>(false);
 
     const LoadData = (): void => {
         DatabaseService.GetStats().then(setStats);
@@ -35,8 +38,20 @@ export const StatsChart = () => {
         });
     };
 
+    const LoadCommunityData = (): void => {
+        DatabaseService.GetConfig().then((config) => {
+            setOptedIn(config.CommunityOptIn);
+            if (config.CommunityOptIn) {
+                DatabaseService.SubmitCommunityStats().then(() => {
+                    DatabaseService.GetCommunityStats().then(setCommunityStats);
+                });
+            }
+        });
+    };
+
     useEffect(() => {
         LoadData();
+        LoadCommunityData();
 
         const unsubscribe = DatabaseService.OnRecordsUpdated(() => {
             LoadData();
@@ -219,7 +234,89 @@ export const StatsChart = () => {
                     </Stack>
                 </Group>
             </Paper>
+            {optedIn && communityStats !== null && communityStats.SampleSize > 0 && (
+                <Paper shadow="sm" radius="md" p="lg" withBorder>
+                    <Group justify="space-between" align="flex-start" mb="md">
+                        <Stack gap={2}>
+                            <Group gap="xs">
+                                <IconUsers size={20} color="var(--mantine-color-grape-6)" />
+                                <Title order={4}>社区对比</Title>
+                            </Group>
+                            <Text size="sm" c="dimmed">
+                                你和社区匿名用户的本周对比（基于 {communityStats.SampleSize} 位用户）
+                            </Text>
+                        </Stack>
+                        <Badge variant="light" color="grape" size="sm">匿名聚合</Badge>
+                    </Group>
+
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                        <ComparisonCard
+                            label="本周次数"
+                            myValue={stats.FrequencyPerWeek}
+                            communityValue={communityStats.MedianCount}
+                            unit="次"
+                            color="green"
+                        />
+                        <ComparisonCard
+                            label="本周平均时长"
+                            myValue={stats.WeeklyAverageDuration}
+                            communityValue={communityStats.MedianDuration}
+                            unit="分钟"
+                            color="cyan"
+                            decimals={1}
+                        />
+                    </SimpleGrid>
+                </Paper>
+            )}
+
+            {optedIn && communityStats === null && (
+                <Paper shadow="sm" radius="md" p="md" withBorder>
+                    <Group gap="xs">
+                        <IconUsers size={18} color="var(--mantine-color-dimmed)" />
+                        <Text size="sm" c="dimmed">社区数据加载中，或暂无足够样本...</Text>
+                    </Group>
+                </Paper>
+            )}
         </Stack>
+    );
+};
+
+const ComparisonCard = ({
+    label,
+    myValue,
+    communityValue,
+    unit,
+    color,
+    decimals = 0,
+}: {
+    label: string;
+    myValue: number;
+    communityValue: number;
+    unit: string;
+    color: string;
+    decimals?: number;
+}) => {
+    const max: number = Math.max(myValue, communityValue, 1);
+    const myPercent: number = (myValue / max) * 100;
+    const communityPercent: number = (communityValue / max) * 100;
+    const formatVal = (v: number): string => decimals > 0 ? v.toFixed(decimals) : String(v);
+
+    return (
+        <Paper p="md" radius="md" withBorder>
+            <Text size="sm" fw={500} mb="sm">{label}</Text>
+            <Stack gap="xs">
+                <Group justify="space-between">
+                    <Text size="xs" c="dimmed">你</Text>
+                    <Text size="sm" fw={600} c={color}>{formatVal(myValue)} {unit}</Text>
+                </Group>
+                <Progress value={myPercent} color={color} size="sm" radius="xl" />
+                <Group justify="space-between">
+                    <Text size="xs" c="dimmed">社区中位数</Text>
+                    <Text size="sm" fw={600} c="grape">{formatVal(communityValue)} {unit}</Text>
+                </Group>
+                <Progress value={communityPercent} color="grape" size="sm" radius="xl" />
+            </Stack>
+        </Paper>
     );
 };
 

--- a/src/renderer/views/StatsChart.tsx
+++ b/src/renderer/views/StatsChart.tsx
@@ -1,12 +1,60 @@
 import { useState, useEffect, type ReactNode } from "react";
-import { Paper, Title, SimpleGrid, Stack, Text, Group, Box, Tooltip, ThemeIcon, Progress, Badge } from "@mantine/core";
-import { IconChartBar, IconClock, IconDroplet, IconHistory, IconUsers } from "@tabler/icons-react";
+import {
+    Paper, Title, SimpleGrid, Stack, Text, Group, Box,
+    Tooltip, ThemeIcon, Progress, Badge, Button, Loader,
+} from "@mantine/core";
+import { IconChartBar, IconClock, IconDroplet, IconHistory, IconUsers, IconBrain } from "@tabler/icons-react";
+import {
+    AreaChart, Area, XAxis, YAxis, CartesianGrid,
+    Tooltip as ChartTooltip, ResponsiveContainer,
+    RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
+    BarChart, Bar,
+} from "recharts";
 import { DatabaseService } from "../services/DatabaseService";
-import type { IStats, IDailyCount, ICommunityStats } from "../types/IRecord";
+import type { IStats, IDailyCount, ICommunityStats, IHourlyCount, IWeekdayCount, IMonthlyCount } from "../types/IRecord";
 
 const DAYS_IN_WEEK: number = 7;
 const WEEKS_TO_SHOW: number = 4;
 const WEEKDAYS: string[] = ["一", "二", "三", "四", "五", "六", "日"];
+const WEEKDAY_FULL: string[] = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
+const TREND_DAYS: number = 90;
+const CHART_HEIGHT: number = 280;
+
+// 时长分桶配置
+const DURATION_BINS: { Label: string; Min: number; Max: number }[] = [
+    { Label: "0-5", Min: 0, Max: 5 },
+    { Label: "5-10", Min: 5, Max: 10 },
+    { Label: "10-15", Min: 10, Max: 15 },
+    { Label: "15-20", Min: 15, Max: 20 },
+    { Label: "20-30", Min: 20, Max: 30 },
+    { Label: "30+", Min: 30, Max: Infinity },
+];
+
+// 填充缺失日期，确保趋势图连续
+const FillDailyGaps = (counts: IDailyCount[], days: number): { Date: string; Count: number }[] => {
+    const map = new Map<string, number>();
+    for (const c of counts) {
+        map.set(c.Date, c.Count);
+    }
+    const result: { Date: string; Count: number }[] = [];
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    for (let i = days - 1; i >= 0; i--) {
+        const d = new Date(now);
+        d.setDate(d.getDate() - i);
+        const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        result.push({ Date: key, Count: map.get(key) ?? 0 });
+    }
+    return result;
+};
+
+// 将原始时长数组按分桶统计
+const BuildDurationBins = (durations: number[]): { Label: string; Count: number }[] => {
+    return DURATION_BINS.map((bin) => ({
+        Label: bin.Label,
+        Count: durations.filter((d) => d >= bin.Min && d < bin.Max).length,
+    }));
+};
 
 export const StatsChart = () => {
     const [stats, setStats] = useState<IStats>({
@@ -19,23 +67,53 @@ export const StatsChart = () => {
     const [dailyCounts, setDailyCounts] = useState<Map<string, number>>(new Map());
     const [communityStats, setCommunityStats] = useState<ICommunityStats | null>(null);
     const [optedIn, setOptedIn] = useState<boolean>(false);
+    const [trendData, setTrendData] = useState<{ Date: string; Count: number }[]>([]);
+    const [hourlyData, setHourlyData] = useState<IHourlyCount[]>([]);
+    const [weekdayData, setWeekdayData] = useState<IWeekdayCount[]>([]);
+    const [monthlyData, setMonthlyData] = useState<IMonthlyCount[]>([]);
+    const [durationData, setDurationData] = useState<{ Label: string; Count: number }[]>([]);
+    const [aiResult, setAiResult] = useState<string | null>(null);
+    const [aiLoading, setAiLoading] = useState<boolean>(false);
+    const [aiError, setAiError] = useState<string | null>(null);
 
     const LoadData = (): void => {
-        DatabaseService.GetStats().then(setStats);
+        const onError = (err: unknown): void => {
+            console.error("[StatsChart] 数据加载失败:", err);
+        };
 
+        DatabaseService.GetStats().then(setStats).catch(onError);
+
+        // 热力图数据（4 周）
         const now = new Date();
         now.setHours(23, 59, 59, 999);
-        const startDate = new Date(now);
-        startDate.setDate(now.getDate() - (DAYS_IN_WEEK * WEEKS_TO_SHOW - 1));
-        startDate.setHours(0, 0, 0, 0);
+        const heatmapStart = new Date(now);
+        heatmapStart.setDate(now.getDate() - (DAYS_IN_WEEK * WEEKS_TO_SHOW - 1));
+        heatmapStart.setHours(0, 0, 0, 0);
 
-        DatabaseService.GetDailyCounts(startDate, now).then((counts: IDailyCount[]) => {
+        DatabaseService.GetDailyCounts(heatmapStart, now).then((counts: IDailyCount[]) => {
             const map = new Map<string, number>();
             for (const item of counts) {
                 map.set(item.Date, item.Count);
             }
             setDailyCounts(map);
-        });
+        }).catch(onError);
+
+        // 趋势图数据（90 天）
+        const trendStart = new Date(now);
+        trendStart.setDate(now.getDate() - (TREND_DAYS - 1));
+        trendStart.setHours(0, 0, 0, 0);
+
+        DatabaseService.GetDailyCounts(trendStart, now).then((counts: IDailyCount[]) => {
+            setTrendData(FillDailyGaps(counts, TREND_DAYS));
+        }).catch(onError);
+
+        // 图表聚合数据
+        DatabaseService.GetHourlyDistribution().then(setHourlyData).catch(onError);
+        DatabaseService.GetWeekdayDistribution().then(setWeekdayData).catch(onError);
+        DatabaseService.GetMonthlyTrend().then(setMonthlyData).catch(onError);
+        DatabaseService.GetDurationDistribution().then((durations: number[]) => {
+            setDurationData(BuildDurationBins(durations));
+        }).catch(onError);
     };
 
     const LoadCommunityData = (): void => {
@@ -56,11 +134,26 @@ export const StatsChart = () => {
         const unsubscribe = DatabaseService.OnRecordsUpdated(() => {
             LoadData();
         });
-
         return () => {
             unsubscribe();
         };
     }, []);
+
+    const HandleAiAnalysis = async (): Promise<void> => {
+        setAiLoading(true);
+        setAiError(null);
+        try {
+            const result = await DatabaseService.RequestAiAnalysis();
+            setAiResult(result);
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : "分析失败";
+            setAiError(message);
+        } finally {
+            setAiLoading(false);
+        }
+    };
+
+    // --- 热力图逻辑（保留原有实现） ---
 
     const GetContributionLevel = (count: number): number => {
         if (count === 0) return 0;
@@ -128,17 +221,36 @@ export const StatsChart = () => {
     const monthLabels = GetMonthLabels();
     const hasRecords: boolean = stats.TotalCount > 0;
 
+    // 雷达图数据：只在有数据时格式化
+    const radarData = hourlyData.map((h) => ({
+        Hour: `${h.Hour}时`,
+        Count: h.Count,
+    }));
+
+    // 星期柱状图数据
+    const weekdayChartData = weekdayData.map((d, i) => ({
+        Day: WEEKDAY_FULL[i]!,
+        Count: d.Count,
+    }));
+
+    // 月度趋势：简化月份标签
+    const monthlyChartData = monthlyData.map((m) => ({
+        Month: m.Month.slice(5),
+        Count: m.Count,
+    }));
+
     return (
         <Stack gap="lg" maw={860} mx="auto">
             <Stack gap={4}>
                 <Title order={3} c="blue">
-                    统计
+                    数据仪表盘
                 </Title>
                 <Text size="sm" c="dimmed">
-                    查看累计数据和最近 4 周的记录分布。
+                    综合统计、趋势分析和 AI 洞察。
                 </Text>
             </Stack>
 
+            {/* 统计卡片 */}
             <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing="md">
                 <StatCard
                     title="总次数"
@@ -170,20 +282,17 @@ export const StatsChart = () => {
                 />
             </SimpleGrid>
 
+            {/* 发射日历热力图 */}
             <Paper shadow="sm" radius="md" p="lg" withBorder>
                 <Group justify="space-between" align="flex-start" mb="md">
                     <Stack gap={2}>
-                        <Title order={4}>
-                            发射日历
-                        </Title>
+                        <Title order={4}>发射日历</Title>
                         <Text size="sm" c="dimmed">
                             颜色越深，代表当天记录次数越多。
                         </Text>
                     </Stack>
                     {!hasRecords && (
-                        <Text size="sm" c="dimmed">
-                            暂无可统计数据
-                        </Text>
+                        <Text size="sm" c="dimmed">暂无可统计数据</Text>
                     )}
                 </Group>
 
@@ -277,6 +386,214 @@ export const StatsChart = () => {
                     </Group>
                 </Paper>
             )}
+
+            {/* 每日趋势折线图 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Stack gap={2} mb="md">
+                    <Title order={4}>每日趋势</Title>
+                    <Text size="sm" c="dimmed">最近 {TREND_DAYS} 天的频率变化</Text>
+                </Stack>
+                <Box h={CHART_HEIGHT}>
+                    <ResponsiveContainer width="100%" height="100%">
+                        <AreaChart data={trendData}>
+                            <defs>
+                                <linearGradient id="trendGradient" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="5%" stopColor="#228be6" stopOpacity={0.4} />
+                                    <stop offset="95%" stopColor="#228be6" stopOpacity={0.05} />
+                                </linearGradient>
+                            </defs>
+                            <CartesianGrid strokeDasharray="3 3" stroke="#e9ecef" />
+                            <XAxis
+                                dataKey="Date"
+                                tick={{ fontSize: 11, fill: "#868e96" }}
+                                tickFormatter={(v) => String(v).slice(5)}
+                                interval={13}
+                            />
+                            <YAxis
+                                tick={{ fontSize: 11, fill: "#868e96" }}
+                                allowDecimals={false}
+                            />
+                            <ChartTooltip
+                                formatter={(value) => [`${value} 次`, "次数"]}
+                                labelFormatter={(label) => `日期: ${label}`}
+                            />
+                            <Area
+                                type="monotone"
+                                dataKey="Count"
+                                stroke="#228be6"
+                                strokeWidth={2}
+                                fill="url(#trendGradient)"
+                            />
+                        </AreaChart>
+                    </ResponsiveContainer>
+                </Box>
+            </Paper>
+
+            {/* 月度趋势柱状图 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Stack gap={2} mb="md">
+                    <Title order={4}>月度对比</Title>
+                    <Text size="sm" c="dimmed">最近 12 个月的频率对比</Text>
+                </Stack>
+                <Box h={CHART_HEIGHT}>
+                    <ResponsiveContainer width="100%" height="100%">
+                        <BarChart data={monthlyChartData}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="#e9ecef" />
+                            <XAxis
+                                dataKey="Month"
+                                tick={{ fontSize: 11, fill: "#868e96" }}
+                                tickFormatter={(v) => `${v}月`}
+                            />
+                            <YAxis tick={{ fontSize: 11, fill: "#868e96" }} allowDecimals={false} />
+                            <ChartTooltip
+                                formatter={(value) => [`${value} 次`, "次数"]}
+                                labelFormatter={(label) => `${label}月`}
+                            />
+                            <Bar dataKey="Count" fill="#7950f2" radius={[4, 4, 0, 0]} />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </Box>
+            </Paper>
+
+            {/* 双列图表：时段雷达 + 星期分布 */}
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+                <Paper shadow="sm" radius="md" p="lg" withBorder>
+                    <Stack gap={2} mb="md">
+                        <Title order={4}>24 小时分布</Title>
+                        <Text size="sm" c="dimmed">一天中哪个时段最活跃</Text>
+                    </Stack>
+                    <Box h={CHART_HEIGHT}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <RadarChart data={radarData}>
+                                <PolarGrid stroke="#e9ecef" />
+                                <PolarAngleAxis
+                                    dataKey="Hour"
+                                    tick={{ fontSize: 10, fill: "#868e96" }}
+                                    tickFormatter={(v) => {
+                                        const hour = parseInt(String(v), 10);
+                                        return hour % 3 === 0 ? String(v) : "";
+                                    }}
+                                />
+                                <PolarRadiusAxis tick={{ fontSize: 10, fill: "#adb5bd" }} />
+                                <Radar
+                                    dataKey="Count"
+                                    stroke="#15aabf"
+                                    fill="#15aabf"
+                                    fillOpacity={0.3}
+                                    strokeWidth={2}
+                                />
+                                <ChartTooltip
+                                    formatter={(value) => [`${value} 次`, "次数"]}
+                                />
+                            </RadarChart>
+                        </ResponsiveContainer>
+                    </Box>
+                </Paper>
+
+                <Paper shadow="sm" radius="md" p="lg" withBorder>
+                    <Stack gap={2} mb="md">
+                        <Title order={4}>星期分布</Title>
+                        <Text size="sm" c="dimmed">每周哪天最活跃</Text>
+                    </Stack>
+                    <Box h={CHART_HEIGHT}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart data={weekdayChartData}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="#e9ecef" />
+                                <XAxis dataKey="Day" tick={{ fontSize: 12, fill: "#868e96" }} />
+                                <YAxis tick={{ fontSize: 11, fill: "#868e96" }} allowDecimals={false} />
+                                <ChartTooltip
+                                    formatter={(value) => [`${value} 次`, "次数"]}
+                                />
+                                <Bar dataKey="Count" fill="#40c057" radius={[4, 4, 0, 0]} />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </Box>
+                </Paper>
+            </SimpleGrid>
+
+            {/* 时长分布直方图 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Stack gap={2} mb="md">
+                    <Title order={4}>时长分布</Title>
+                    <Text size="sm" c="dimmed">每次持续时长（分钟）的分布</Text>
+                </Stack>
+                <Box h={CHART_HEIGHT}>
+                    <ResponsiveContainer width="100%" height="100%">
+                        <BarChart data={durationData}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="#e9ecef" />
+                            <XAxis
+                                dataKey="Label"
+                                tick={{ fontSize: 12, fill: "#868e96" }}
+                                tickFormatter={(v) => `${v}分`}
+                            />
+                            <YAxis tick={{ fontSize: 11, fill: "#868e96" }} allowDecimals={false} />
+                            <ChartTooltip
+                                formatter={(value) => [`${value} 次`, "次数"]}
+                                labelFormatter={(label) => `${label} 分钟`}
+                            />
+                            <Bar dataKey="Count" fill="#fd7e14" radius={[4, 4, 0, 0]} />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </Box>
+            </Paper>
+
+            {/* AI 数据分析 */}
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Group justify="space-between" align="flex-start" mb="md">
+                    <Stack gap={2}>
+                        <Group gap="xs">
+                            <ThemeIcon variant="light" color="grape" size="sm">
+                                <IconBrain size={14} />
+                            </ThemeIcon>
+                            <Title order={4}>AI 数据分析</Title>
+                        </Group>
+                        <Text size="sm" c="dimmed">
+                            基于所有统计数据生成智能分析报告（可在设置中配置 AI 服务商）
+                        </Text>
+                    </Stack>
+                    <Button
+                        variant="light"
+                        color="grape"
+                        size="sm"
+                        onClick={HandleAiAnalysis}
+                        loading={aiLoading}
+                        disabled={!hasRecords}
+                    >
+                        {aiResult !== null ? "重新分析" : "开始分析"}
+                    </Button>
+                </Group>
+
+                {aiLoading && (
+                    <Group justify="center" py="xl">
+                        <Loader color="grape" size="sm" />
+                        <Text size="sm" c="dimmed">正在分析数据...</Text>
+                    </Group>
+                )}
+
+                {aiError !== null && (
+                    <Paper p="md" radius="sm" bg="red.0">
+                        <Text size="sm" c="red.7">{aiError}</Text>
+                    </Paper>
+                )}
+
+                {aiResult !== null && !aiLoading && aiError === null && (
+                    <Paper p="md" radius="sm" bg="grape.0">
+                        <Stack gap="xs">
+                            {aiResult.split("\n").filter((line) => line.trim() !== "").map((line, i) => (
+                                <Text key={i} size="sm" c="dark.6" style={{ lineHeight: 1.6 }}>
+                                    {line}
+                                </Text>
+                            ))}
+                        </Stack>
+                    </Paper>
+                )}
+
+                {aiResult === null && !aiLoading && aiError === null && (
+                    <Text size="sm" c="dimmed" ta="center" py="lg">
+                        点击"开始分析"按钮，获取 AI 生成的数据洞察报告。
+                    </Text>
+                )}
+            </Paper>
         </Stack>
     );
 };

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+  },
+});

--- a/worker/migrations/0001_init.sql
+++ b/worker/migrations/0001_init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS stats (
+    contributor_id TEXT NOT NULL,
+    week_id        TEXT NOT NULL,
+    count          INTEGER NOT NULL,
+    avg_duration   REAL NOT NULL,
+    updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (contributor_id, week_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stats_week ON stats (week_id);

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dickhelper-community-worker",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0",
+    "@cloudflare/workers-types": "^4.20250501.0",
+    "typescript": "~5.7.2"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,132 @@
+// 社区匿名聚合统计 Cloudflare Worker（D1 后端）
+
+interface Env {
+    DB: D1Database;
+}
+
+interface ISubmitPayload {
+    ContributorId: string;
+    WeekId: string;
+    Count: number;
+    AvgDuration: number;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+    "Access-Control-Allow-Origin": "null",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+};
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_COUNT = 100;
+const MAX_DURATION = 480;
+
+export default {
+    async fetch(request: Request, env: Env): Promise<Response> {
+        if (request.method === "OPTIONS") {
+            return new Response(null, { status: 204, headers: CORS_HEADERS });
+        }
+
+        const url = new URL(request.url);
+
+        if (url.pathname === "/api/submit" && request.method === "POST") {
+            return HandleSubmit(request, env);
+        }
+
+        if (url.pathname === "/api/community" && request.method === "GET") {
+            return HandleGetCommunity(url, env);
+        }
+
+        return JsonResponse({ error: "Not found" }, 404);
+    },
+};
+
+async function HandleSubmit(request: Request, env: Env): Promise<Response> {
+    let payload: ISubmitPayload;
+    try {
+        payload = await request.json() as ISubmitPayload;
+    } catch {
+        return JsonResponse({ error: "Invalid JSON" }, 400);
+    }
+
+    if (
+        typeof payload.ContributorId !== "string" || !UUID_REGEX.test(payload.ContributorId) ||
+        typeof payload.WeekId !== "string" || !/^\d{4}-W\d{2}$/.test(payload.WeekId) ||
+        typeof payload.Count !== "number" || !Number.isInteger(payload.Count) || payload.Count < 0 || payload.Count > MAX_COUNT ||
+        typeof payload.AvgDuration !== "number" || payload.AvgDuration < 0 || payload.AvgDuration > MAX_DURATION
+    ) {
+        return JsonResponse({ error: "Invalid payload" }, 400);
+    }
+
+    // 每个 contributorId + weekId 只保留一条，重复提交覆盖
+    await env.DB.prepare(
+        `INSERT OR REPLACE INTO stats (contributor_id, week_id, count, avg_duration, updated_at)
+         VALUES (?, ?, ?, ?, datetime('now'))`
+    ).bind(payload.ContributorId, payload.WeekId, payload.Count, payload.AvgDuration).run();
+
+    return JsonResponse({ ok: true });
+}
+
+async function HandleGetCommunity(url: URL, env: Env): Promise<Response> {
+    const weekId: string | null = url.searchParams.get("weekId");
+    if (weekId === null || !/^\d{4}-W\d{2}$/.test(weekId)) {
+        return JsonResponse({ error: "Missing or invalid weekId" }, 400);
+    }
+
+    // 查询该周全部提交
+    const { results } = await env.DB.prepare(
+        `SELECT count, avg_duration FROM stats WHERE week_id = ?`
+    ).bind(weekId).all<{ count: number; avg_duration: number }>();
+
+    if (results.length === 0) {
+        return JsonResponse({
+            WeekId: weekId,
+            MedianCount: 0,
+            MedianDuration: 0,
+            SampleSize: 0,
+        });
+    }
+
+    // IQR 过滤 + 中位数
+    const counts: number[] = results.map((r) => r.count);
+    const durations: number[] = results.map((r) => r.avg_duration);
+    const filteredCounts: number[] = FilterOutliers(counts);
+    const filteredDurations: number[] = FilterOutliers(durations);
+    const medianCount: number = Median(filteredCounts.length > 0 ? filteredCounts : counts);
+    const medianDuration: number = Median(filteredDurations.length > 0 ? filteredDurations : durations);
+
+    return JsonResponse({
+        WeekId: weekId,
+        MedianCount: Math.round(medianCount * 10) / 10,
+        MedianDuration: Math.round(medianDuration * 10) / 10,
+        SampleSize: results.length,
+    });
+}
+
+function Median(values: number[]): number {
+    if (values.length === 0) return 0;
+    const arr: number[] = [...values].sort((a, b) => a - b);
+    const mid: number = Math.floor(arr.length / 2);
+    if (arr.length % 2 === 0) {
+        return (arr[mid - 1]! + arr[mid]!) / 2;
+    }
+    return arr[mid]!;
+}
+
+function FilterOutliers(values: number[]): number[] {
+    if (values.length < 4) return values;
+    const sorted: number[] = [...values].sort((a, b) => a - b);
+    const q1: number = Median(sorted.slice(0, Math.floor(sorted.length / 2)));
+    const q3: number = Median(sorted.slice(Math.ceil(sorted.length / 2)));
+    const iqr: number = q3 - q1;
+    const lower: number = q1 - 1.5 * iqr;
+    const upper: number = q3 + 1.5 * iqr;
+    return sorted.filter((v) => v >= lower && v <= upper);
+}
+
+function JsonResponse(data: unknown, status: number = 200): Response {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+}

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "dickhelper-community"
+main = "src/index.ts"
+compatibility_date = "2025-05-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "dickhelper-community"
+database_id = "YOUR_D1_DATABASE_ID"


### PR DESCRIPTION
## Summary
- 新增仪表盘视图：每日趋势折线图、月度柱状图、24小时雷达图、星期分布图、时长直方图
- 集成 AI 分析，支持 6 种 provider：
  - Anthropic (Claude)
  - OpenAI (GPT)
  - Google Gemini
  - Ollama（本地 LLM）
  - 自定义 CLI 命令（调用任意本地模型/工具）
  - 本地规则分析（无需 API，零配置可用）
- Settings 页面新增 AI 配置面板：provider 切换、API key 加密存储、模型选择、Ollama URL、CLI 命令
- 安全加固：API key 使用系统密钥链加密（safeStorage）、CLI 参数校验防注入、settings key 白名单、Ollama 仅允许本地连接

## Changes
- `src/main/ai-service.ts`: AI 分析服务（6 provider 实现 + 超时 + 输出限制）
- `src/main/database.ts`: safeStorage 加密设置、小时/星期/月度分布查询、时长数据查询
- `src/main/index.ts`: 注册图表数据 + 设置 + AI 分析 IPC handlers，settings key 白名单
- `src/preload/`: 暴露 AI 分析、图表数据、设置 API
- `src/renderer/views/StatsChart.tsx`: 完整 Dashboard 视图（recharts 图表 + AI 分析面板）
- `src/renderer/views/Settings.tsx`: AI 配置面板（provider 选择、密钥输入、模型配置）
- `src/renderer/services/DatabaseService.ts`: 新增图表/AI/设置调用封装
- `src/renderer/types/IRecord.ts`: 新增 IHourlyCount、IWeekdayCount、IMonthlyCount 类型
- `.github/workflows/release.yml`: CI 改进（package version 校验、构建产物收集优化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)