### PR TITLE
feat: optimize community stats with caching and rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "electron-updater": "^6.8.3",
+    "recharts": "^3.8.1",
     "sql.js": "^1.14.0"
   },
   "devDependencies": {

--- a/packages/shared/src/IRecord.ts
+++ b/packages/shared/src/IRecord.ts
@@ -17,6 +17,7 @@ export interface IRecordRaw {
 export interface IStats {
     readonly TotalCount: number;
     readonly AverageDuration: number;
+    readonly WeeklyAverageDuration: number;
     readonly FrequencyPerWeek: number;
     readonly FrequencyPerMonth: number;
 }
@@ -30,4 +31,19 @@ export interface IImportResult {
     readonly Imported: number;
     readonly Skipped: number;
     readonly Rejected: number;
+}
+
+// 社区聚合统计
+export interface ICommunityStats {
+    readonly WeekId: string;
+    readonly MedianCount: number;
+    readonly MedianDuration: number;
+    readonly SampleSize: number;
+}
+
+// 应用配置
+export interface IAppConfig {
+    readonly CommunityOptIn: boolean;
+    readonly ContributorId: string | null;
+    readonly ApiEndpoint: string;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,2 @@
 export type { UpdateSource, UpdateStatus, IUpdateSettings, IUpdateState } from "./IUpdate";
-export type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult } from "./IRecord";
+export type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig } from "./IRecord";

--- a/src/main/community.ts
+++ b/src/main/community.ts
@@ -1,0 +1,74 @@
+// 社区匿名统计 HTTP 客户端
+
+interface ICommunityStatsResponse {
+    WeekId: string;
+    MedianCount: number;
+    MedianDuration: number;
+    SampleSize: number;
+}
+
+interface ISubmitPayload {
+    ContributorId: string;
+    WeekId: string;
+    Count: number;
+    AvgDuration: number;
+}
+
+// ISO 8601 标准周：周一起始，第一周包含该年第一个周四
+export function GetCurrentWeekId(): string {
+    const now = new Date();
+    const d = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const weekNo: number = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+    return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+export class CommunityService {
+    private readonly _apiEndpoint: string;
+    private readonly _timeoutMs: number = 8000;
+
+    public constructor(apiEndpoint: string) {
+        this._apiEndpoint = apiEndpoint.replace(/\/+$/, "");
+    }
+
+    public async SubmitStats(
+        contributorId: string,
+        weekId: string,
+        count: number,
+        avgDuration: number
+    ): Promise<boolean> {
+        const payload: ISubmitPayload = {
+            ContributorId: contributorId,
+            WeekId: weekId,
+            Count: count,
+            AvgDuration: avgDuration,
+        };
+
+        try {
+            const response: Response = await fetch(`${this._apiEndpoint}/api/submit`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+                signal: AbortSignal.timeout(this._timeoutMs),
+            });
+            return response.ok;
+        } catch {
+            return false;
+        }
+    }
+
+    public async GetCommunityStats(weekId: string): Promise<ICommunityStatsResponse | null> {
+        try {
+            const response: Response = await fetch(
+                `${this._apiEndpoint}/api/community?weekId=${encodeURIComponent(weekId)}`,
+                { signal: AbortSignal.timeout(this._timeoutMs) }
+            );
+            if (!response.ok) return null;
+            const data: ICommunityStatsResponse = await response.json() as ICommunityStatsResponse;
+            return data;
+        } catch {
+            return null;
+        }
+    }
+}

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import path from "node:path";
+import { app } from "electron";
+import { randomUUID } from "node:crypto";
+
+interface ICachedCommunityStats {
+    WeekId: string;
+    MedianCount: number;
+    MedianDuration: number;
+    SampleSize: number;
+    FetchedAt: string;
+}
+
+interface IConfigData {
+    CommunityOptIn: boolean;
+    ContributorId: string | null;
+    ApiEndpoint: string;
+    LastSubmitTime: string | null;
+    CachedCommunityStats: ICachedCommunityStats | null;
+}
+
+const DEFAULT_API_ENDPOINT = "https://dickhelper-api.your-worker.workers.dev";
+
+const DEFAULT_CONFIG: IConfigData = {
+    CommunityOptIn: false,
+    ContributorId: null,
+    ApiEndpoint: DEFAULT_API_ENDPOINT,
+    LastSubmitTime: null,
+    CachedCommunityStats: null,
+};
+
+export class ConfigService {
+    private _config: IConfigData;
+    private readonly _configPath: string;
+
+    public constructor() {
+        this._configPath = path.join(app.getPath("userData"), "config.json");
+        this._config = this._load();
+    }
+
+    private _load(): IConfigData {
+        if (!fs.existsSync(this._configPath)) {
+            return { ...DEFAULT_CONFIG };
+        }
+        try {
+            const raw: string = fs.readFileSync(this._configPath, "utf-8");
+            const parsed: Partial<IConfigData> = JSON.parse(raw);
+            return {
+                CommunityOptIn: typeof parsed.CommunityOptIn === "boolean" ? parsed.CommunityOptIn : DEFAULT_CONFIG.CommunityOptIn,
+                ContributorId: typeof parsed.ContributorId === "string" ? parsed.ContributorId : DEFAULT_CONFIG.ContributorId,
+                ApiEndpoint: typeof parsed.ApiEndpoint === "string" ? parsed.ApiEndpoint : DEFAULT_CONFIG.ApiEndpoint,
+                LastSubmitTime: typeof parsed.LastSubmitTime === "string" ? parsed.LastSubmitTime : DEFAULT_CONFIG.LastSubmitTime,
+                CachedCommunityStats: parsed.CachedCommunityStats !== null && parsed.CachedCommunityStats !== undefined
+                    && typeof parsed.CachedCommunityStats === "object"
+                    ? parsed.CachedCommunityStats
+                    : DEFAULT_CONFIG.CachedCommunityStats,
+            };
+        } catch {
+            return { ...DEFAULT_CONFIG };
+        }
+    }
+
+    private _save(): void {
+        fs.writeFileSync(this._configPath, JSON.stringify(this._config, null, 2), "utf-8");
+    }
+
+    public GetConfig(): IConfigData {
+        return { ...this._config };
+    }
+
+    // 仅允许设置 CommunityOptIn，ApiEndpoint 不通过 IPC 暴露
+    public SetConfig(partial: { CommunityOptIn?: boolean }): IConfigData {
+        if (partial.CommunityOptIn !== undefined) {
+            this._config.CommunityOptIn = partial.CommunityOptIn;
+            // 首次 opt-in 时生成 contributorId
+            if (partial.CommunityOptIn && this._config.ContributorId === null) {
+                this._config.ContributorId = randomUUID();
+            }
+        }
+        this._save();
+        return { ...this._config };
+    }
+
+    // 距离上次提交是否超过 6 小时
+    public ShouldSubmit(): boolean {
+        const THROTTLE_MS: number = 6 * 60 * 60 * 1000;
+        if (this._config.LastSubmitTime === null) return true;
+        const elapsed: number = Date.now() - new Date(this._config.LastSubmitTime).getTime();
+        return elapsed >= THROTTLE_MS;
+    }
+
+    public RecordSubmitTime(): void {
+        this._config.LastSubmitTime = new Date().toISOString();
+        this._save();
+    }
+
+    // 社区统计缓存是否在 1 小时内
+    public GetCachedCommunityStats(): ICachedCommunityStats | null {
+        const CACHE_TTL_MS: number = 60 * 60 * 1000;
+        const cached: ICachedCommunityStats | null = this._config.CachedCommunityStats;
+        if (cached === null) return null;
+        const age: number = Date.now() - new Date(cached.FetchedAt).getTime();
+        if (age >= CACHE_TTL_MS) return null;
+        return cached;
+    }
+
+    public SetCachedCommunityStats(stats: Omit<ICachedCommunityStats, "FetchedAt">): void {
+        this._config.CachedCommunityStats = {
+            ...stats,
+            FetchedAt: new Date().toISOString(),
+        };
+        this._save();
+    }
+}

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -45,6 +45,12 @@ export class DatabaseService {
                 Notes     TEXT
             )
         `);
+        db.run(`
+            CREATE TABLE IF NOT EXISTS Settings (
+                Key   TEXT PRIMARY KEY,
+                Value TEXT NOT NULL
+            )
+        `);
         return new DatabaseService(db, dbPath);
     }
 
@@ -118,6 +124,7 @@ export class DatabaseService {
     public GetStats(): {
         TotalCount: number;
         AverageDuration: number;
+        WeeklyAverageDuration: number;
         FrequencyPerWeek: number;
         FrequencyPerMonth: number;
     } {
@@ -134,7 +141,7 @@ export class DatabaseService {
         );
 
         const weekRow = this._queryOne(
-            `SELECT COUNT(*) as count FROM ${TABLE_NAME} WHERE EndTime >= ?`,
+            `SELECT COUNT(*) as count, AVG(Duration) as avgDur FROM ${TABLE_NAME} WHERE EndTime >= ?`,
             [oneWeekAgo.toISOString()]
         );
 
@@ -146,8 +153,23 @@ export class DatabaseService {
         return {
             TotalCount: (totalRow?.count as number) ?? 0,
             AverageDuration: (totalRow?.avgDur as number) ?? 0,
+            WeeklyAverageDuration: (weekRow?.avgDur as number) ?? 0,
             FrequencyPerWeek: (weekRow?.count as number) ?? 0,
             FrequencyPerMonth: (monthRow?.count as number) ?? 0,
+        };
+    }
+
+    // 本周统计：次数和平均时长（仅最近 7 天）
+    public GetWeeklyStats(): { Count: number; AvgDuration: number } {
+        const now = new Date();
+        const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        const row = this._queryOne(
+            `SELECT COUNT(*) as count, AVG(Duration) as avgDur FROM ${TABLE_NAME} WHERE EndTime >= ?`,
+            [oneWeekAgo.toISOString()]
+        );
+        return {
+            Count: (row?.count as number) ?? 0,
+            AvgDuration: (row?.avgDur as number) ?? 0,
         };
     }
 
@@ -239,6 +261,71 @@ export class DatabaseService {
         const skipped = totalValid - imported.length;
 
         return { Imported: imported.length, Skipped: skipped, Rejected: rejected };
+    }
+
+    /** 按小时统计次数（本地时区，0-23） */
+    public GetHourlyDistribution(): { Hour: number; Count: number }[] {
+        const rows = this._queryAll(`SELECT EndTime FROM ${TABLE_NAME}`);
+        const counts: number[] = new Array(24).fill(0) as number[];
+        for (const row of rows) {
+            const d = new Date((row as { EndTime: string }).EndTime);
+            counts[d.getHours()]!++;
+        }
+        return counts.map((count, hour) => ({ Hour: hour, Count: count }));
+    }
+
+    /** 按星期统计次数（0=周一 到 6=周日） */
+    public GetWeekdayDistribution(): { Weekday: number; Count: number }[] {
+        const rows = this._queryAll(`SELECT EndTime FROM ${TABLE_NAME}`);
+        const counts: number[] = new Array(7).fill(0) as number[];
+        for (const row of rows) {
+            const d = new Date((row as { EndTime: string }).EndTime);
+            const day: number = (d.getDay() + 6) % 7;
+            counts[day]!++;
+        }
+        return counts.map((count, day) => ({ Weekday: day, Count: count }));
+    }
+
+    /** 按月统计次数（最近 12 个月） */
+    public GetMonthlyTrend(): { Month: string; Count: number }[] {
+        const now = new Date();
+        const startDate = new Date(now.getFullYear() - 1, now.getMonth(), 1);
+        const rows = this._queryAll(
+            `SELECT EndTime FROM ${TABLE_NAME} WHERE EndTime >= ?`,
+            [startDate.toISOString()]
+        );
+        const countMap = new Map<string, number>();
+        for (const row of rows) {
+            const d = new Date((row as { EndTime: string }).EndTime);
+            const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+            countMap.set(key, (countMap.get(key) ?? 0) + 1);
+        }
+        const result: { Month: string; Count: number }[] = [];
+        const cursor = new Date(startDate);
+        while (cursor <= now) {
+            const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`;
+            result.push({ Month: key, Count: countMap.get(key) ?? 0 });
+            cursor.setMonth(cursor.getMonth() + 1);
+        }
+        return result;
+    }
+
+    /** 获取所有记录的持续时长（分钟） */
+    public GetAllDurations(): number[] {
+        const rows = this._queryAll(`SELECT Duration FROM ${TABLE_NAME}`);
+        return rows.map((row) => (row as { Duration: number }).Duration);
+    }
+
+    /** 读取设置项 */
+    public GetSetting(key: string): string | null {
+        const row = this._queryOne(`SELECT Value FROM Settings WHERE Key = ?`, [key]);
+        return row !== undefined ? (row.Value as string) : null;
+    }
+
+    /** 写入设置项 */
+    public SetSetting(key: string, value: string): void {
+        this._db.run(`INSERT OR REPLACE INTO Settings (Key, Value) VALUES (?, ?)`, [key, value]);
+        this._save();
     }
 
     public Close(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,15 @@
 import { app, BrowserWindow, Tray, Menu, ipcMain, nativeImage, shell } from "electron";
 import path from "node:path";
 import { DatabaseService } from "./database";
+import { ConfigService } from "./config";
+import { CommunityService, GetCurrentWeekId } from "./community";
 import { UpdateService } from "./updateService";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let databaseService: DatabaseService | null = null;
+let configService: ConfigService | null = null;
+let communityService: CommunityService | null = null;
 let updateService: UpdateService | null = null;
 let isQuitting: boolean = false;
 
@@ -170,6 +174,53 @@ function RegisterIpcHandlers(): void {
         return result;
     });
 
+    // 配置相关
+    ipcMain.handle("config:get", () => {
+        return configService!.GetConfig();
+    });
+
+    ipcMain.handle("config:set", (...args) => {
+        const partial = args[1] as { CommunityOptIn?: boolean };
+        return configService!.SetConfig(partial);
+    });
+
+    // 社区统计：优先返回本地缓存，缓存过期时才请求远端
+    ipcMain.handle("community:get-stats", async () => {
+        const cached = configService!.GetCachedCommunityStats();
+        if (cached !== null) {
+            return { WeekId: cached.WeekId, MedianCount: cached.MedianCount, MedianDuration: cached.MedianDuration, SampleSize: cached.SampleSize };
+        }
+        const weekId: string = GetCurrentWeekId();
+        const result = await communityService!.GetCommunityStats(weekId);
+        if (result !== null) {
+            configService!.SetCachedCommunityStats(result);
+        }
+        return result;
+    });
+
+    // 社区提交：6 小时内只提交一次
+    ipcMain.handle("community:submit", async () => {
+        const config = configService!.GetConfig();
+        if (!config.CommunityOptIn || config.ContributorId === null) {
+            return false;
+        }
+        if (!configService!.ShouldSubmit()) {
+            return true;
+        }
+        const weeklyStats = databaseService!.GetWeeklyStats();
+        const weekId: string = GetCurrentWeekId();
+        const ok: boolean = await communityService!.SubmitStats(
+            config.ContributorId,
+            weekId,
+            weeklyStats.Count,
+            weeklyStats.AvgDuration
+        );
+        if (ok) {
+            configService!.RecordSubmitTime();
+        }
+        return ok;
+    });
+
     ipcMain.handle("updates:get-state", () => {
         return updateService!.GetState();
     });
@@ -196,6 +247,10 @@ function RegisterIpcHandlers(): void {
     });
 
     ipcMain.handle("shell:open-external", (_event, url: string) => {
+        const parsed: URL = new URL(url);
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+            throw new Error(`不允许的协议: ${parsed.protocol}`);
+        }
         return shell.openExternal(url);
     });
 }
@@ -207,7 +262,6 @@ if (!gotTheLock) {
     app.quit();
 } else {
     app.on("second-instance", () => {
-        // 当用户再次尝试打开应用时，聚焦已有窗口
         if (mainWindow) {
             if (mainWindow.isMinimized()) {
                 mainWindow.restore();
@@ -221,6 +275,9 @@ if (!gotTheLock) {
         console.log("[Main] App ready");
         databaseService = await DatabaseService.create();
         console.log("[Main] DatabaseService initialized");
+        configService = new ConfigService();
+        communityService = new CommunityService(configService.GetConfig().ApiEndpoint);
+        console.log("[Main] ConfigService & CommunityService initialized");
         updateService = new UpdateService(() => mainWindow);
         RegisterIpcHandlers();
         CreateWindow();
@@ -229,7 +286,6 @@ if (!gotTheLock) {
         console.log("[Main] Startup complete");
 
         app.on("activate", () => {
-            // macOS: 点击 dock 图标时重新创建窗口
             if (BrowserWindow.getAllWindows().length === 0) {
                 CreateWindow();
             } else {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,5 +1,5 @@
 // 声明 window.electronAPI 类型，让渲染进程可以直接使用
-import type { IRecordRaw, IStats, IDailyCount, IImportResult, IUpdateSettings, IUpdateState, UpdateSource } from "@dickhelper/shared";
+import type { IRecordRaw, IStats, IDailyCount, IImportResult, IUpdateSettings, IUpdateState, UpdateSource, ICommunityStats, IAppConfig } from "@dickhelper/shared";
 
 interface IImportRecord {
     Id: string;
@@ -27,7 +27,11 @@ declare global {
             InstallUpdate: () => Promise<void>;
             OnRecordsUpdated: (callback: () => void) => () => void;
             OnUpdateStateChanged: (callback: (state: IUpdateState) => void) => () => void;
-            OpenExternal: (url: string) => Promise<boolean>;
+            OpenExternal: (url: string) => Promise<void>;
+            GetConfig: () => Promise<IAppConfig>;
+            SetConfig: (partial: { CommunityOptIn?: boolean }) => Promise<IAppConfig>;
+            GetCommunityStats: () => Promise<ICommunityStats | null>;
+            SubmitCommunityStats: () => Promise<boolean>;
         };
     }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,10 @@ const electronAPI = {
         };
     },
     OpenExternal: (url: string): Promise<void> => ipcRenderer.invoke("shell:open-external", url),
+    GetConfig: (): Promise<unknown> => ipcRenderer.invoke("config:get"),
+    SetConfig: (partial: { CommunityOptIn?: boolean }): Promise<unknown> => ipcRenderer.invoke("config:set", partial),
+    GetCommunityStats: (): Promise<unknown> => ipcRenderer.invoke("community:get-stats"),
+    SubmitCommunityStats: (): Promise<boolean> => ipcRenderer.invoke("community:submit"),
 };
 
 try {

--- a/src/renderer/services/DatabaseService.ts
+++ b/src/renderer/services/DatabaseService.ts
@@ -1,4 +1,4 @@
-import type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult } from "@dickhelper/shared";
+import type { IRecord, IRecordRaw, IStats, IDailyCount, IImportResult, ICommunityStats, IAppConfig } from "@dickhelper/shared";
 
 // 检查 electronAPI 是否可用，不在 Electron 环境时给出明确错误
 function GetApi(): Window["electronAPI"] {
@@ -130,6 +130,22 @@ export class DatabaseService {
      */
     public static OnRecordsUpdated(callback: () => void): () => void {
         return GetApi().OnRecordsUpdated(callback);
+    }
+
+    public static async GetConfig(): Promise<IAppConfig> {
+        return GetApi().GetConfig();
+    }
+
+    public static async SetConfig(partial: { CommunityOptIn?: boolean }): Promise<IAppConfig> {
+        return GetApi().SetConfig(partial);
+    }
+
+    public static async GetCommunityStats(): Promise<ICommunityStats | null> {
+        return GetApi().GetCommunityStats();
+    }
+
+    public static async SubmitCommunityStats(): Promise<boolean> {
+        return GetApi().SubmitCommunityStats();
     }
 
     private static MapRawToRecord(raw: IRecordRaw): IRecord {

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import {
     Alert,
     Paper,
@@ -12,6 +12,7 @@ import {
     rem,
     Divider,
     Badge,
+    Switch,
     SegmentedControl,
 } from "@mantine/core";
 import {
@@ -23,6 +24,7 @@ import {
     IconRocket,
     IconStar,
     IconUpload,
+    IconUsers,
     IconWorld,
 } from "@tabler/icons-react";
 import { DatabaseService } from "../services/DatabaseService";
@@ -64,8 +66,22 @@ export const Settings = () => {
     const { records, refresh } = useRecords();
     const { UpdateState } = useUpdateState();
     const [importMessage, setImportMessage] = useState<string | null>(null);
+    const [communityOptIn, setCommunityOptIn] = useState<boolean>(false);
+    const [configLoaded, setConfigLoaded] = useState<boolean>(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const importTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        DatabaseService.GetConfig().then((config) => {
+            setCommunityOptIn(config.CommunityOptIn);
+            setConfigLoaded(true);
+        });
+    }, []);
+
+    const HandleOptInToggle = async (checked: boolean): Promise<void> => {
+        setCommunityOptIn(checked);
+        await DatabaseService.SetConfig({ CommunityOptIn: checked });
+    };
 
     const updateSource: UpdateSource = UpdateState?.Source ?? "mirror";
     const currentVersion: string = UpdateState?.CurrentVersion ?? "2.0.0";
@@ -195,6 +211,29 @@ export const Settings = () => {
                         {importMessage}
                     </Notification>
                 )}
+            </Paper>
+
+            <Paper shadow="sm" radius="md" p="lg" withBorder>
+                <Group justify="space-between" align="flex-start" mb="xs">
+                    <Group gap="sm">
+                        <IconUsers size={22} />
+                        <Title order={4}>社区统计</Title>
+                    </Group>
+                    {configLoaded && (
+                        <Switch
+                            checked={communityOptIn}
+                            onChange={(e) => HandleOptInToggle(e.currentTarget.checked)}
+                            size="md"
+                        />
+                    )}
+                </Group>
+                <Text size="sm" c="dimmed" mb="xs">
+                    匿名参与社区聚合统计，查看你和社区平均水平的对比。
+                </Text>
+                <Text size="xs" c="dimmed">
+                    开启后仅上报本周次数和平均时长两个数字，不含任何个人信息、时间戳或记录详情。
+                    数据通过随机 ID 匿名提交，无法关联到你的身份。可随时关闭。
+                </Text>
             </Paper>
 
             <Paper shadow="sm" radius="md" p="lg" withBorder>

--- a/src/renderer/views/StatsChart.tsx
+++ b/src/renderer/views/StatsChart.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, type ReactNode } from "react";
-import { Paper, Title, SimpleGrid, Stack, Text, Group, Box, Tooltip, ThemeIcon } from "@mantine/core";
-import { IconChartBar, IconClock, IconDroplet, IconHistory } from "@tabler/icons-react";
+import { Paper, Title, SimpleGrid, Stack, Text, Group, Box, Tooltip, ThemeIcon, Progress, Badge } from "@mantine/core";
+import { IconChartBar, IconClock, IconDroplet, IconHistory, IconUsers } from "@tabler/icons-react";
 import { DatabaseService } from "../services/DatabaseService";
-import type { IStats, IDailyCount } from "@dickhelper/shared";
+import type { IStats, IDailyCount, ICommunityStats } from "@dickhelper/shared";
 
 const DAYS_IN_WEEK: number = 7;
 const WEEKS_TO_SHOW: number = 4;
@@ -12,10 +12,13 @@ export const StatsChart = () => {
     const [stats, setStats] = useState<IStats>({
         TotalCount: 0,
         AverageDuration: 0,
+        WeeklyAverageDuration: 0,
         FrequencyPerWeek: 0,
         FrequencyPerMonth: 0,
     });
     const [dailyCounts, setDailyCounts] = useState<Map<string, number>>(new Map());
+    const [communityStats, setCommunityStats] = useState<ICommunityStats | null>(null);
+    const [optedIn, setOptedIn] = useState<boolean>(false);
 
     const LoadData = (): void => {
         DatabaseService.GetStats().then(setStats);
@@ -35,8 +38,20 @@ export const StatsChart = () => {
         });
     };
 
+    const LoadCommunityData = (): void => {
+        const onErr = (err: unknown): void => { console.error("[StatsChart] 社区数据加载失败:", err); };
+        DatabaseService.GetConfig().then((config) => {
+            setOptedIn(config.CommunityOptIn);
+            if (config.CommunityOptIn) {
+                DatabaseService.GetCommunityStats().then(setCommunityStats).catch(onErr);
+                DatabaseService.SubmitCommunityStats().catch(onErr);
+            }
+        }).catch(onErr);
+    };
+
     useEffect(() => {
         LoadData();
+        LoadCommunityData();
 
         const unsubscribe = DatabaseService.OnRecordsUpdated(() => {
             LoadData();
@@ -219,7 +234,89 @@ export const StatsChart = () => {
                     </Stack>
                 </Group>
             </Paper>
+            {optedIn && communityStats !== null && communityStats.SampleSize > 0 && (
+                <Paper shadow="sm" radius="md" p="lg" withBorder>
+                    <Group justify="space-between" align="flex-start" mb="md">
+                        <Stack gap={2}>
+                            <Group gap="xs">
+                                <IconUsers size={20} color="var(--mantine-color-grape-6)" />
+                                <Title order={4}>社区对比</Title>
+                            </Group>
+                            <Text size="sm" c="dimmed">
+                                你和社区匿名用户的本周对比（基于 {communityStats.SampleSize} 位用户）
+                            </Text>
+                        </Stack>
+                        <Badge variant="light" color="grape" size="sm">匿名聚合</Badge>
+                    </Group>
+
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                        <ComparisonCard
+                            label="本周次数"
+                            myValue={stats.FrequencyPerWeek}
+                            communityValue={communityStats.MedianCount}
+                            unit="次"
+                            color="green"
+                        />
+                        <ComparisonCard
+                            label="本周平均时长"
+                            myValue={stats.WeeklyAverageDuration}
+                            communityValue={communityStats.MedianDuration}
+                            unit="分钟"
+                            color="cyan"
+                            decimals={1}
+                        />
+                    </SimpleGrid>
+                </Paper>
+            )}
+
+            {optedIn && communityStats === null && (
+                <Paper shadow="sm" radius="md" p="md" withBorder>
+                    <Group gap="xs">
+                        <IconUsers size={18} color="var(--mantine-color-dimmed)" />
+                        <Text size="sm" c="dimmed">社区数据加载中，或暂无足够样本...</Text>
+                    </Group>
+                </Paper>
+            )}
         </Stack>
+    );
+};
+
+const ComparisonCard = ({
+    label,
+    myValue,
+    communityValue,
+    unit,
+    color,
+    decimals = 0,
+}: {
+    label: string;
+    myValue: number;
+    communityValue: number;
+    unit: string;
+    color: string;
+    decimals?: number;
+}) => {
+    const max: number = Math.max(myValue, communityValue, 1);
+    const myPercent: number = (myValue / max) * 100;
+    const communityPercent: number = (communityValue / max) * 100;
+    const formatVal = (v: number): string => decimals > 0 ? v.toFixed(decimals) : String(v);
+
+    return (
+        <Paper p="md" radius="md" withBorder>
+            <Text size="sm" fw={500} mb="sm">{label}</Text>
+            <Stack gap="xs">
+                <Group justify="space-between">
+                    <Text size="xs" c="dimmed">你</Text>
+                    <Text size="sm" fw={600} c={color}>{formatVal(myValue)} {unit}</Text>
+                </Group>
+                <Progress value={myPercent} color={color} size="sm" radius="xl" />
+                <Group justify="space-between">
+                    <Text size="xs" c="dimmed">社区中位数</Text>
+                    <Text size="sm" fw={600} c="grape">{formatVal(communityValue)} {unit}</Text>
+                </Group>
+                <Progress value={communityPercent} color="grape" size="sm" radius="xl" />
+            </Stack>
+        </Paper>
     );
 };
 

--- a/worker/migrations/0001_init.sql
+++ b/worker/migrations/0001_init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS stats (
+    contributor_id TEXT NOT NULL,
+    week_id        TEXT NOT NULL,
+    count          INTEGER NOT NULL,
+    avg_duration   REAL NOT NULL,
+    updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (contributor_id, week_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stats_week ON stats (week_id);

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dickhelper-community-worker",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0",
+    "@cloudflare/workers-types": "^4.20250501.0",
+    "typescript": "~5.7.2"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,157 @@
+// 社区匿名聚合统计 Cloudflare Worker（D1 后端）
+
+interface Env {
+    DB: D1Database;
+}
+
+interface ISubmitPayload {
+    ContributorId: string;
+    WeekId: string;
+    Count: number;
+    AvgDuration: number;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+};
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_COUNT = 100;
+const MAX_DURATION = 480;
+
+export default {
+    async fetch(request: Request, env: Env): Promise<Response> {
+        if (request.method === "OPTIONS") {
+            return new Response(null, { status: 204, headers: CORS_HEADERS });
+        }
+
+        const url = new URL(request.url);
+
+        if (url.pathname === "/api/submit" && request.method === "POST") {
+            return HandleSubmit(request, env);
+        }
+
+        if (url.pathname === "/api/community" && request.method === "GET") {
+            return HandleGetCommunity(url, env);
+        }
+
+        return JsonResponse({ error: "Not found" }, 404);
+    },
+};
+
+async function HandleSubmit(request: Request, env: Env): Promise<Response> {
+    let payload: ISubmitPayload;
+    try {
+        payload = await request.json() as ISubmitPayload;
+    } catch {
+        return JsonResponse({ error: "Invalid JSON" }, 400);
+    }
+
+    if (
+        typeof payload.ContributorId !== "string" || !UUID_REGEX.test(payload.ContributorId) ||
+        typeof payload.WeekId !== "string" || !/^\d{4}-W\d{2}$/.test(payload.WeekId) ||
+        typeof payload.Count !== "number" || !Number.isInteger(payload.Count) || payload.Count < 0 || payload.Count > MAX_COUNT ||
+        typeof payload.AvgDuration !== "number" || payload.AvgDuration < 0 || payload.AvgDuration > MAX_DURATION
+    ) {
+        return JsonResponse({ error: "Invalid payload" }, 400);
+    }
+
+    // 防刷：同一 contributor 60 秒内只允许一次提交
+    const lastUpdate = await env.DB.prepare(
+        `SELECT updated_at FROM stats WHERE contributor_id = ? ORDER BY updated_at DESC LIMIT 1`
+    ).bind(payload.ContributorId).first<{ updated_at: string }>();
+
+    if (lastUpdate !== null) {
+        const elapsed: number = Date.now() - new Date(lastUpdate.updated_at + "Z").getTime();
+        if (elapsed < 60_000) {
+            return JsonResponse({ error: "Rate limited, retry after 60s" }, 429);
+        }
+    }
+
+    // 每个 contributorId + weekId 只保留一条，重复提交覆盖
+    await env.DB.prepare(
+        `INSERT OR REPLACE INTO stats (contributor_id, week_id, count, avg_duration, updated_at)
+         VALUES (?, ?, ?, ?, datetime('now'))`
+    ).bind(payload.ContributorId, payload.WeekId, payload.Count, payload.AvgDuration).run();
+
+    // 惰性清理：删除 26 周（半年）前的数据
+    await env.DB.prepare(
+        `DELETE FROM stats WHERE week_id < ?`
+    ).bind(WeekIdNWeeksAgo(26)).run();
+
+    return JsonResponse({ ok: true });
+}
+
+async function HandleGetCommunity(url: URL, env: Env): Promise<Response> {
+    const weekId: string | null = url.searchParams.get("weekId");
+    if (weekId === null || !/^\d{4}-W\d{2}$/.test(weekId)) {
+        return JsonResponse({ error: "Missing or invalid weekId" }, 400);
+    }
+
+    // 查询该周全部提交
+    const { results } = await env.DB.prepare(
+        `SELECT count, avg_duration FROM stats WHERE week_id = ?`
+    ).bind(weekId).all<{ count: number; avg_duration: number }>();
+
+    if (results.length === 0) {
+        return JsonResponse({
+            WeekId: weekId,
+            MedianCount: 0,
+            MedianDuration: 0,
+            SampleSize: 0,
+        });
+    }
+
+    // IQR 过滤 + 中位数
+    const counts: number[] = results.map((r) => r.count);
+    const durations: number[] = results.map((r) => r.avg_duration);
+    const filteredCounts: number[] = FilterOutliers(counts);
+    const filteredDurations: number[] = FilterOutliers(durations);
+    const medianCount: number = Median(filteredCounts.length > 0 ? filteredCounts : counts);
+    const medianDuration: number = Median(filteredDurations.length > 0 ? filteredDurations : durations);
+
+    return JsonResponse({
+        WeekId: weekId,
+        MedianCount: Math.round(medianCount * 10) / 10,
+        MedianDuration: Math.round(medianDuration * 10) / 10,
+        SampleSize: results.length,
+    });
+}
+
+function Median(values: number[]): number {
+    if (values.length === 0) return 0;
+    const arr: number[] = [...values].sort((a, b) => a - b);
+    const mid: number = Math.floor(arr.length / 2);
+    if (arr.length % 2 === 0) {
+        return (arr[mid - 1]! + arr[mid]!) / 2;
+    }
+    return arr[mid]!;
+}
+
+function FilterOutliers(values: number[]): number[] {
+    if (values.length < 4) return values;
+    const sorted: number[] = [...values].sort((a, b) => a - b);
+    const q1: number = Median(sorted.slice(0, Math.floor(sorted.length / 2)));
+    const q3: number = Median(sorted.slice(Math.ceil(sorted.length / 2)));
+    const iqr: number = q3 - q1;
+    const lower: number = q1 - 1.5 * iqr;
+    const upper: number = q3 + 1.5 * iqr;
+    return sorted.filter((v) => v >= lower && v <= upper);
+}
+
+function WeekIdNWeeksAgo(n: number): string {
+    const d = new Date(Date.now() - n * 7 * 86400_000);
+    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const weekNo: number = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400_000 + 1) / 7);
+    return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+function JsonResponse(data: unknown, status: number = 200): Response {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+}

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "dickhelper-community"
+main = "src/index.ts"
+compatibility_date = "2025-05-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "dickhelper-community"
+database_id = "YOUR_D1_DATABASE_ID"


### PR DESCRIPTION
## Summary
- Add anonymous community aggregate statistics with Cloudflare D1 worker
- Add community opt-in settings with contributor ID management
- Add stats comparison display (median count/duration vs community)
- Add server-side rate limiting and client-side request throttling
- Add URL protocol validation in shell:open-external (security hardening)
- Add recharts dependency for data visualization